### PR TITLE
Add convex factorization machine (#7)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,30 +4,41 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
+    - name: Install lapack
+      run: |
+        sudo apt update
+        sudo apt install gfortran
+        sudo apt install libblas-dev liblapack-dev libatlas-base-dev
+
     - name: Cache choosenim
       id: cache-choosenim
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.choosenim
         key: ${{ runner.os }}-choosenim-1.0.6
+
     - name: Cache nimble
       id: cache-nimble
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-1.0.6
+
     - name: Install Nim
       if: steps.cache-choosenim.outputs.cache-hit != 'true' || steps.cache-nimble.outputs.cache-hit != 'true'
       run: |
         export CHOOSENIM_CHOOSE_VERSION="1.0.6"
         curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
         sh init.sh -y
+
     - name: Install project
       run: |
         export PATH=$HOME/.nimble/bin:$PATH
         nimble install -y
         echo ::add-path::$HOME/.nimble/bin
+
     - name: Unit testing
       run: |
         nimble test

--- a/README.md
+++ b/README.md
@@ -4,20 +4,21 @@ A library for factorization machines in [Nim](https://nim-lang.org/).
 [![Actions Status](https://github.com/neonnnnn/nimfm/workflows/Build/badge.svg)](https://github.com/neonnnnn/nimfm/actions)
 
 
-Factorization machines (FMs)\[1, 2\] are machine learning models using second-order
+Factorization machines (FMs)[1, 2] are machine learning models using second-order
 feature combinations (e.g., x1 * x2, x2 * x5) efficiently.
 
 nimfm provides
 
- - Not-only second-order but also higher-order factorization machines \[3\].
+ - Not-only second-order but also higher-order factorization machines [3].
  - Coordinate descent (a.k.a alternative least squares) solver.
- - Stochastic gradient descent solver with some step-size scheduling methods \[4\].
- - Various loss functions: Squared, SquaredHinge, and Logistic.
+ - Stochastic gradient descent solver with some step-size scheduling methods [4].
+ - Greedy coordinate descent [5] and Frank-Wolfe [6] (with some heuristics)) solvers for convex factorization machines are also provided.
+ - Various loss functions: Squared, Huber, SquaredHinge, and Logistic.
  - Binary file for end users.
 
 ## Data format
 nimfm uses its own data type for datasets: `CSRDataset` and `CSCDataset` and provides procs for loading **[libsvm](https://www.csie.ntu.edu.tw/~cjlin/libsvm/)/[svmlight](http://svmlight.joachims.org/) format** file as such datasets.
-`CSRDataset` is for `SGD` solver and `CSCDataset` is for `CoordinateDescent` solver.
+`CSRDataset` is for `SGD` solver and `CSCDataset` is for `CD`, `GreedyCD`, and `Hazan` solvers.
 The two-dimensional sequence `seq[seq[float64]]` is easily transformed to such
 datasets by `toCSR` and `toCSC`.
 
@@ -48,13 +49,17 @@ Then, nimfm binary will be created in the ./bin directory.
 
 1. S. Rendle. Factorization machines. In ICDM, pp. 995--1000, 2010.
 
-2. S. Rendle. Factorization machines with libfm.  ACM Transactions on Intelligent Systems and Technology, 3(3):57--78, 2012.
+2. S. Rendle. Factorization machines with libfm. ACM Transactions on Intelligent Systems and Technology, 3(3):57--78, 2012.
 
 3. M. Blondel, A. Fujino, N. Ueda, M. Ishihata. Higher-order factorization machines. In NeurIPS, pp. 3351--3359, 2016.
 
 4. L. Bottou. Stochastic gradient descent tricks. Neural Networks, Tricks of the Trade, Reloaded, pp. 430–445, 
  Lecture Notes in Computer Science (LNCS 7700), Springer, 2012.
 
+5. M. Blondel, A. Fujino, and N. Ueda. Convex factorization machines. In ECML-PKDD, pp. 19--35, 2015.
+
+6. M. Yamada, W. Lian, A. Goyal, J. Chen, K. Wimalawarne, S. A. Khan, S. Kaski, H. Mamitsuka, and Y. Chang.
+   Convex factorization machine for toxicogenomics prediction. In KDD, pp. 1215--1224, 2017.
 
 ## Authors
  - Kyohei Atarashi, 2020-present

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ nimfm provides
  - Not-only second-order but also higher-order factorization machines [3].
  - Coordinate descent (a.k.a alternative least squares) solver.
  - Stochastic gradient descent solver with some step-size scheduling methods [4].
- - Greedy coordinate descent [5] and Frank-Wolfe [6] (with some heuristics)) solvers for convex factorization machines are also provided.
+ - Greedy coordinate descent [5] and Hazan's (Frank-Wolfe) algorithm [6] (with some heuristics) solvers for convex factorization machines.
  - Various loss functions: Squared, Huber, SquaredHinge, and Logistic.
  - Binary file for end users.
 

--- a/benchmarks/ml100k/convex_factorization_machine.nim
+++ b/benchmarks/ml100k/convex_factorization_machine.nim
@@ -12,7 +12,8 @@ when isMainModule:
   var cfm = newConvexFactorizationMachine(
     task=regression, beta=1e-4, alpha0=1e-8, alpha=1e-8,
     maxComponents=50, ignoreDiag=true)
-  var gcd = newGreedyCoordinateDescent(maxIter=100)
+  var gcd = newGreedyCoordinateDescent(
+    maxIter=100, maxIterPower=1000, tolPower=1e-8)
   gcd.fit(Xtr, yTr, cfm)
 
   echo("Train RMSE: ", cfm.score(Xtr, yTr))

--- a/benchmarks/ml100k/convex_factorization_machine.nim
+++ b/benchmarks/ml100k/convex_factorization_machine.nim
@@ -1,0 +1,19 @@
+import nimfm
+
+
+when isMainModule:
+  var XTr, XTe: CSCDataset
+  var yTr, yTe: seq[float64]
+  loadSVMLightFile("ml-100k_user_item_feature_train.svm",
+                    XTr, yTr, nFeatures=2703)
+  loadSVMLightFile("ml-100k_user_item_feature_test.svm",
+                    XTe, yTe, nFeatures=2703)
+
+  var cfm = newConvexFactorizationMachine(
+    task=regression, beta=1e-4, alpha0=1e-8, alpha=1e-8,
+    maxComponents=50, ignoreDiag=true)
+  var gcd = newGreedyCoordinateDescent(maxIter=100)
+  gcd.fit(Xtr, yTr, cfm)
+
+  echo("Train RMSE: ", cfm.score(Xtr, yTr))
+  echo("Test RMSE: ", cfm.score(Xte, yTe))

--- a/benchmarks/ml100k/convex_factorization_machine.nim
+++ b/benchmarks/ml100k/convex_factorization_machine.nim
@@ -1,20 +1,25 @@
 import nimfm
 
-
 when isMainModule:
   var XTr, XTe: CSCDataset
   var yTr, yTe: seq[float64]
-  loadSVMLightFile("ml-100k_user_item_feature_train.svm",
-                    XTr, yTr, nFeatures=2703)
-  loadSVMLightFile("ml-100k_user_item_feature_test.svm",
-                    XTe, yTe, nFeatures=2703)
+  loadSVMLightFile("ml-100k_user_item_train.svm",
+                    XTr, yTr, nFeatures=2625)
+  loadSVMLightFile("ml-100k_user_item_test.svm",
+                    XTe, yTe, nFeatures=2625)
 
   var cfm = newConvexFactorizationMachine(
     task=regression, beta=1e-4, alpha0=1e-8, alpha=1e-8,
-    maxComponents=50, ignoreDiag=true)
-  var gcd = newGreedyCoordinateDescent(
-    maxIter=100, maxIterPower=1000, tolPower=1e-8)
-  gcd.fit(Xtr, yTr, cfm)
+    maxComponents=50, ignoreDiag=true, fitLinear=true,
+    fitIntercept=true, eta=600, warmStart=true)
 
+  var gcd = newGreedyCD(
+    maxIter=10, maxIterInner=10, maxIterPower=100,
+    refitFully=false, nRefitting=100, verbose=1)
+
+  var hazan = newHazan(maxIter=100, maxIterPower=100, optimal=true, verbose=1,
+                       nTol=100)
+  #hazan.fit(Xtr, yTr, cfm)
+  gcd.fit(Xtr, yTr, cfm)
   echo("Train RMSE: ", cfm.score(Xtr, yTr))
   echo("Test RMSE: ", cfm.score(Xte, yTe))

--- a/benchmarks/ml100k/factorization_machine.nim
+++ b/benchmarks/ml100k/factorization_machine.nim
@@ -11,7 +11,7 @@ when isMainModule:
 
   var fm = newFactorizationMachine(task=regression, beta=1e-3, 
                                    alpha0=1e-10, alpha=1e-10)
-  var cd = newCoordinateDescent(maxIter=100)
+  var cd = newCD(maxIter=100)
   cd.fit(Xtr, yTr, fm)
 
   echo("Train RMSE: ", fm.score(Xtr, yTr))

--- a/benchmarks/ml100k/factorization_machine_sgd.nim
+++ b/benchmarks/ml100k/factorization_machine_sgd.nim
@@ -4,7 +4,7 @@ import nimfm
 when isMainModule:
   var XTr, XTe: CSRDataset  # Use CSRDataset for SGD solver
   var yTr, yTe: seq[float64]
-  let scheduling: SchedulingKind = optimal
+  let scheduling: SchedulingKind = constant
   loadSVMLightFile("ml-100k_user_item_feature_train.svm",
                     XTr, yTr, nFeatures=2703)
   loadSVMLightFile("ml-100k_user_item_feature_test.svm",

--- a/benchmarks/ml100k/higher_order_factorization_machine.nim
+++ b/benchmarks/ml100k/higher_order_factorization_machine.nim
@@ -11,7 +11,7 @@ when isMainModule:
 
   var fm = newFactorizationMachine(task=regression, degree=3, beta=1e-3,
                                    alpha0=1e-10, alpha=1e-10)
-  var cd = newCoordinateDescent(maxIter=100)
+  var cd = newCD(maxIter=100)
   cd.fit(Xtr, yTr, fm)
 
   echo("Train RMSE: ", fm.score(Xtr, yTr))

--- a/benchmarks/ml100k/linear_model.nim
+++ b/benchmarks/ml100k/linear_model.nim
@@ -10,7 +10,7 @@ when isMainModule:
                     XTe, yTe, nFeatures=2703)
 
   var fm = newFactorizationMachine(task=regression, degree=1)
-  var cd = newCoordinateDescent(maxIter=100)
+  var cd = newCD(maxIter=1000)
   cd.fit(Xtr, yTr, fm)
 
   echo("Train RMSE: ", fm.score(Xtr, yTr))

--- a/benchmarks/ml100k/make_ml100k_dataset.nim
+++ b/benchmarks/ml100k/make_ml100k_dataset.nim
@@ -146,7 +146,7 @@ proc createUserItemFeatureDataset(indices: openarray[int]) =
   let nTrain = int(8*X.nSamples/10)
   (XTr, yTr) = shuffle(XAll, y, indices[0..<nTrain])
   (XTe, yTe) = shuffle(XAll, y, indices[nTrain..^1])
-  dumpSVMLightFile("ml100k_user_item_feature_all.svm", XAll, y)
+  dumpSVMLightFile("ml-100k_user_item_feature_all.svm", XAll, y)
   dumpSVMLightFile("ml-100k_user_item_feature_train.svm", Xtr, yTr)
   dumpSVMLightFile("ml-100k_user_item_feature_test.svm", Xte, yTe)
   

--- a/benchmarks/ml100k/matrix_factorization.nim
+++ b/benchmarks/ml100k/matrix_factorization.nim
@@ -8,7 +8,7 @@ when isMainModule:
   loadSVMLightFile("ml-100k_user_item_test.svm", XTe, yTe, nFeatures=2625)
 
   var fm = newFactorizationMachine(task=regression, beta=3e-4, alpha=1e-10, alpha0=1e-10)
-  var cd = newCoordinateDescent(maxIter=100)
+  var cd = newCD(maxIter=100)
   cd.fit(Xtr, yTr, fm)
 
   echo("Train RMSE: ", fm.score(Xtr, yTr))

--- a/benchmarks/ml100k/user_item_bias.nim
+++ b/benchmarks/ml100k/user_item_bias.nim
@@ -9,7 +9,7 @@ when isMainModule:
 
   var fm = newFactorizationMachine(task=regression, degree=1, 
                                    alpha=1e-10, alpha0=1e-10)
-  var cd = newCoordinateDescent(maxIter=100)
+  var cd = newCD(maxIter=100)
   cd.fit(Xtr, yTr, fm)
 
   echo("Train RMSE: ", fm.score(Xtr, yTr))

--- a/nimfm.nimble
+++ b/nimfm.nimble
@@ -7,7 +7,7 @@ srcDir        = "src"
 
 
 # Dependencies
-requires "nim >= 1.0.6", "cligen >= 0.9.43"
+requires "nim >= 1.0.6", "cligen >= 0.9.43", "nimlapack >= 0.2.0"
 
 # Compile and create binary in ./bin for end users
 task make, "builds nimfm":

--- a/src/nimfm.nim
+++ b/src/nimfm.nim
@@ -1,19 +1,7 @@
-import nimfm/factorization_machine
-import nimfm/convex_factorization_machine
-import nimfm/fm_base
-import nimfm/optimizers/coordinate_descent
-import nimfm/optimizers/sgd
-import nimfm/optimizers/greedy_coordinate_descent
-import nimfm/loss
-import nimfm/dataset
-import nimfm/metrics
-import nimfm/tensor
+import nimfm/modules
+export modules
+import strutils, sugar, sequtils, math, tables, strformat
 
-import strutils, sugar, sequtils, math
-
-export fm_base, factorization_machine, loss, dataset, metrics, tensor
-export sgd, coordinate_descent
-export convex_factorization_machine, greedy_coordinate_descent
 
 # The followings are for end users
 proc echoDataInfo(X: BaseDataset) =
@@ -24,8 +12,8 @@ proc echoDataInfo(X: BaseDataset) =
   echo("   Minimum value      : ", X.min)
 
 
-proc eval(fm: FactorizationMachine, task: TaskKind, test: string,
-          predict: string, nFeatures: int, verbose: int) =
+proc eval[L](fm: FactorizationMachine[L], task: TaskKind, test: string,
+             predict: string, nFeatures: int, verbose: int) =
   var X: CSRDataset
   var y: seq[float64]
   if verbose > 0: echo("Load test data.")
@@ -45,15 +33,15 @@ proc eval(fm: FactorizationMachine, task: TaskKind, test: string,
     f.close()
 
 
-proc train(task: TaskKind, train: string, test = "", degree = 2,
-           nComponents = 30, alpha0 = 1e-7, alpha = 1e-5, beta = 1e-5,
-           loss = Squared, fitLower = explicit, fitLinear = true,
-           fitIntercept = true, scale = 0.1, randomState = 1,
-           solver = "cd", maxIter = 100, tol = 1e-5, eta0 = 0.1,
-           scheduling = optimal, powerIt = 1.0, dump = "", load = "",
-           predict = "", nFeatures = -1, verbose = 1) =
+proc trainInner[L](task: TaskKind, train: string, test = "", degree = 2,
+                   nComponents = 30, alpha0 = 1e-7, alpha = 1e-5, beta = 1e-5,
+                   loss: L=newSquared(), fitLower = explicit, fitLinear = true,
+                   fitIntercept = true, scale = 0.1, randomState = 1,
+                   solver = "cd", maxIter = 100, tol = 1e-5, eta0 = 0.1,
+                   scheduling = optimal, powerIt = 1.0, dump = "", load = "",
+                   predict = "", nFeatures = -1, verbose = 1) =
   ## training a factorization machine
-  var fm: FactorizationMachine
+  var fm: FactorizationMachine[L]
   if load == "":
     fm = newFactorizationMachine(
       task = task, degree = degree, nComponents = nComponents, alpha0 = alpha0,
@@ -62,14 +50,14 @@ proc train(task: TaskKind, train: string, test = "", degree = 2,
       randomState = randomState, scale = scale
     )
   else:
-    load(fm, load, true)
+    load(fm, load, true, loss)
   case solver
     of "cd", "als":
       var X: CSCDataset
       var y: seq[float64]
       loadSVMLightFile(train, X, y, nFeatures)
       if verbose > 0: echoDataInfo(X)
-      var optim = newCoordinateDescent(maxIter, verbose, tol)
+      var optim = newCD(maxIter, verbose, tol)
       optim.fit(X, y, fm)
     of "sgd":
       var X: CSRDataset
@@ -86,15 +74,60 @@ proc train(task: TaskKind, train: string, test = "", degree = 2,
   if dump != "": fm.dump(dump)
 
 
-proc test(task: TaskKind, test, load: string, dump = "",
-          predict = "", nFeatures = -1, verbose = 1) =
-  ## test a factorization machine
-  var fm: FactorizationMachine
-  load(fm, load, false)
+proc train(task: TaskKind, train: string, test = "", degree = 2,
+           nComponents = 30, alpha0 = 1e-7, alpha = 1e-5, beta = 1e-5,
+           loss="squared", fitLower = explicit, fitLinear = true,
+           fitIntercept = true, scale = 0.1, randomState = 1,
+           solver = "cd", maxIter = 100, tol = 1e-5, eta0 = 0.1,
+           scheduling = optimal, powerIt = 1.0, threshold=0.1,
+           dump = "", load = "", predict = "", nFeatures = -1, verbose = 1) =
+  ## training a factorization machine
+  if loss == "squared":
+    trainInner(task, train, test, degree, nComponents, alpha0, alpha, beta,
+               newSquared(), fitLower, fitLinear, fitIntercept, scale,
+               randomState, solver, maxIter, tol, eta0, scheduling, powerIt,
+               dump, load, predict, nFeatures, verbose)
+  elif loss == "huber":
+    trainInner(task, train, test, degree, nComponents, alpha0, alpha, beta,
+               newHuber(threshold), fitLower, fitLinear, fitIntercept, scale,
+               randomState, solver, maxIter, tol, eta0, scheduling, powerIt,
+               dump, load, predict, nFeatures, verbose)
+  elif loss == "squared_hinge":
+    trainInner(task, train, test, degree, nComponents, alpha0, alpha, beta,
+               newSquaredHinge(), fitLower, fitLinear, fitIntercept, scale,
+               randomState, solver, maxIter, tol, eta0, scheduling, powerIt,
+               dump, load, predict, nFeatures, verbose)
+  elif loss == "logistic":
+    trainInner(task, train, test, degree, nComponents, alpha0, alpha, beta,
+               newLogistic(), fitLower, fitLinear, fitIntercept, scale,
+               randomState, solver, maxIter, tol, eta0, scheduling, powerIt, 
+               dump, load, predict, nFeatures, verbose)
+  else:
+    raise newException(ValueError, fmt"loss {loss} is not supported.")
+
+proc testInner[L](task: TaskKind, test, load: string, dump = "", 
+                  loss: L = newSquared(), predict = "", nFeatures = -1,
+                  verbose = 1) =
+  var fm: FactorizationMachine[L]
+  load(fm, load, false, loss)
   eval(fm, task, test, predict, nFeatures, verbose)
   if dump != "": fm.dump(dump)
 
 
+proc test(task: TaskKind, test, load: string, dump = "",  loss="squared", 
+          predict = "", nFeatures = -1, verbose = 1) =
+  ## test a factorization machine
+  if loss == "squared":
+    testInner(task, test, load, dump, newSquared(), predict, nFeatures, verbose)
+  elif loss == "huber":
+    testInner(task, test, load, dump, newHuber(), predict, nFeatures, verbose)
+  elif loss == "squared_hinge":
+    testInner(task, test, load, dump, newSquaredHinge(), predict, nFeatures, 
+              verbose)
+  elif loss == "logistic":
+    testInner(task, test, load, dump, newLogistic(), predict, nFeatures, verbose)
+
+    
 when isMainModule:
   import cligen; include cligen/mergeCfgEnv
 
@@ -127,8 +160,8 @@ Run "$command help" to get *comprehensive* help.$ifVersion"""
      "alpha0": "Regularization strength for intercept (bias) term",
      "alpha": "Regularization sterngth for linear term",
      "beta": "Regularization strength for interaction term",
-     "loss": "Optimized loss function, Squared, SquaredHinge, or Logistic. " &
-             "Ignored when --task:r",
+     "loss": "Optimized loss function, squared, huber, squared_hinge, " &
+             "or logistic",
      "fit-lower": "Whether and how to fit lower-order terms. " &
                   "explicit, augment, or none.",
      "fit-linear": "Whether to fit linear term or not (0 or 1)",
@@ -143,6 +176,7 @@ Run "$command help" to get *comprehensive* help.$ifVersion"""
      "scheduling": "Step-size scheduling method for sgd. " &
                    "optimal, constant, pegasos, or invscaling",
      "power-it": "Hyper-parameter for step-size scheduling",
+     "threshold": "Hyper-parameter for huber loss",
      "dump": "Filename for dumping model",
      "load": "Filename for loading model",
      "predict": "Filename for prediction of test data",

--- a/src/nimfm/convex_factorization_machine.nim
+++ b/src/nimfm/convex_factorization_machine.nim
@@ -1,17 +1,20 @@
 import loss, tensor, kernels, fm_base
-import strutils, parseutils, sequtils, sugar, algorithm
+import strutils, parseutils, sequtils, algorithm, typetraits
 
 
 type
-  ConvexFactorizationMachineObj* = object
+  ConvexFactorizationMachineObj*[L] = object
     task*: TaskKind         ## regression or classification.
     degree*: int            ## Degree of the polynomial, 2.
     maxComponents*: int     ## Maximum number of basis vectors.
     alpha0*: float64        ## Regularization strength for intercept.
     alpha*: float64         ## Regularization strength for linear term.
-    beta*: float64          ## Regularization strengt for higher-order weights.
-    loss*: LossFunctionKind ## Loss function.
-                            ## Squared, SquaredHinge, or Logistic.
+    beta*: float64          ## Regularization strength for higher-order weight
+                            ## matrix. It is used in GreedyCD.
+    eta*: float64           ## Constraint sterngth for the trace norm of
+                            ## higher-order weight matrix. It is used in Hazan.
+    loss*: L                ## Loss function. It must have mu: float64 field and
+                            ## loss/dloss: (float64, float64) -> float64.
     fitIntercept*: bool     ## Whether to fit intercept (a.k.a bias) term.
     fitLinear*: bool        ## Whether to fit linear term.
     ignoreDiag*: bool       ## Whether ignored diag (FM) or not (PN).
@@ -20,27 +23,30 @@ type
     isInitalized*: bool
     P*: Matrix              ## Weights for the polynomial.
                             ## shape (nComponents, nFeatures)
-    lams*: Vector           ## Weights for each base. shape (nComponents, )
-    w*: Vector              ## Weigths for linear term, shape (nFeatures)
-    intercept*: float64     # Intercept term
+    lams*: Vector           ## Weight for vectors in basis.
+                            ## shape: (nComponents)
+    w*: Vector              ## Weigths for linear term, shape: (nFeatures)
+    intercept*: float64     ## Intercept term.
 
-  ConvexFactorizationMachine* = ref ConvexFactorizationMachineObj
+  ConvexFactorizationMachine*[L] = ref ConvexFactorizationMachineObj[L]
 
 
-proc newConvexFactorizationMachine*(
+proc newConvexFactorizationMachine*[L](
   task: TaskKind, maxComponents = 30, alpha0 = 1e-6, alpha = 1e-3,
-  beta = 1e-5, loss = SquaredHinge, fitIntercept = true, fitLinear = true,
-  ignoreDiag=true, warmStart = false): ConvexFactorizationMachine =
+  beta = 1e-5, eta=1000.0, loss: L = newSquared(), fitIntercept = true, 
+  fitLinear = true, ignoreDiag=true, warmStart = false):
+     ConvexFactorizationMachine[L] =
   ## Create a new ConvexFactorizationMachine.
   ## task: classification or regression.
   ## maxComponents: Maximum number of basis vectors.
   ## alpha0: Regularization strength for intercept.
   ## alpha: Regularization strength for linear term.
   ## beta: Regularization strength for higher-order weights.
-  ## loss: Loss function.
-  ##   - Squared: 1/2 (y-p)**2,
-  ##   - SquaredHinge: (max(0, 1-y*p))**2,
-  ##   - Logistic: log (1+exp(-y*p)), where p is the predicted value.
+  ##       It is used in GreedyCD optimizer.
+  ## eta: Constrain of the trace norm of the weight matrix
+  ##      for quadratic term.
+  ## loss: Loss function. It must has mu: float64 field and
+  ##       loss/dloss proc: (float64, float64)->float64.
   ## fitIntercept: Whether to fit intercept (a.k.a bias) term or not.
   ## fitLinear: Whether to fit linear term or not.
   ## warmStart: Whether to do warwm start fitting or not.
@@ -55,9 +61,8 @@ proc newConvexFactorizationMachine*(
   result.alpha0 = alpha0
   result.alpha = alpha
   result.beta = beta
-  case task
-  of regression: result.loss = Squared
-  of classification: result.loss = loss
+  result.eta = eta
+  result.loss = loss
   result.fitIntercept = fitIntercept
   result.fitLinear = fitLinear
   result.ignoreDiag = ignoreDiag
@@ -67,10 +72,11 @@ proc newConvexFactorizationMachine*(
   result.lams = zeros([0])
 
 
-proc init*[Dataset](self: ConvexFactorizationMachine, X: Dataset, force=false) =
+proc init*[Dataset](self: ConvexFactorizationMachine, X: Dataset, 
+                    force=false) =
   ## Initializes the factorization machine.
-  ## If force=false, fm is already initialized, and warmStart=true,
-  ## fm will not be initialized.
+  ## self will not be initialized if force=false, self is already initialized,
+  ## and warmStart=true.
   if force or not (self.warmStart and self.isInitalized):
     let nFeatures: int = X.nFeatures
     self.w = zeros([nFeatures])
@@ -117,7 +123,8 @@ proc dump*(self: ConvexFactorizationMachine, fname: string) =
   f.writeLine("alpha0: ", self.alpha0)
   f.writeLine("alpha: ", self.alpha)
   f.writeLine("beta: ", self.beta)
-  f.writeLine("loss: ", self.loss)
+  f.writeLine("eta: ", self.eta)
+  f.writeLine("loss: ", name(type(self.loss)))
   f.writeLine("fitIntercept: ", self.fitIntercept)
   f.writeLine("fitLinear: ", self.fitLinear)
   f.writeLine("randomState: ", self.randomState)
@@ -135,7 +142,8 @@ proc dump*(self: ConvexFactorizationMachine, fname: string) =
   f.close()
 
 
-proc load*(fm: var ConvexFactorizationMachine, fname: string, warmStart: bool)=
+proc load*[L](fm: var ConvexFactorizationMachine[L], fname: string,
+              warmStart: bool, loss: L) =
   ## Loads the fitted convex factorization machine.
   new(fm)
   var f: File = open(fname, fmRead)
@@ -148,7 +156,12 @@ proc load*(fm: var ConvexFactorizationMachine, fname: string, warmStart: bool)=
   discard parseFloat(f.readLine().split(" ")[1], fm.alpha0, 0)
   discard parseFloat(f.readLine().split(" ")[1], fm.alpha, 0)
   discard parseFloat(f.readLine().split(" ")[1], fm.beta, 0)
-  fm.loss = parseEnum[LossFunctionKind](f.readLine().split(" ")[1])
+  discard parseFloat(f.readLine().split(" ")[1], fm.eta, 0)
+  let lossName = f.readLine().split(" ")[1]
+  fm.loss = loss
+  if name(type(loss)) != lossName:
+    echo("Assert: You define ", name(type(loss)), " loss but loaded model ",
+         "used ", lossName, " loss.")
   fm.fitIntercept = parseBool(f.readLine().split(" ")[1])
   fm.fitLinear = parseBool(f.readLine().split(" ")[1])
   fm.warmStart = warmStart

--- a/src/nimfm/convex_factorization_machine.nim
+++ b/src/nimfm/convex_factorization_machine.nim
@@ -1,0 +1,179 @@
+import loss, tensor, kernels, fm_base
+import strutils, parseutils, sequtils, sugar, algorithm
+
+
+type
+  ConvexFactorizationMachineObj* = object
+    task*: TaskKind         ## regression or classification.
+    degree*: int            ## Degree of the polynomial, 2.
+    maxComponents*: int     ## Maximum number of basis vectors.
+    alpha0*: float64        ## Regularization strength for intercept.
+    alpha*: float64         ## Regularization strength for linear term.
+    beta*: float64          ## Regularization strengt for higher-order weights.
+    loss*: LossFunctionKind ## Loss function.
+                            ## Squared, SquaredHinge, or Logistic.
+    fitIntercept*: bool     ## Whether to fit intercept (a.k.a bias) term.
+    fitLinear*: bool        ## Whether to fit linear term.
+    ignoreDiag*: bool       ## Whether ignored diag (FM) or not (PN).
+    warmStart*: bool        ## Whether to do warwm start fitting.
+    randomState*: int       ## The seed of the pseudo random number generator.
+    isInitalized*: bool
+    P*: Matrix              ## Weights for the polynomial.
+                            ## shape (nComponents, nFeatures)
+    lams*: Vector           ## Weights for each base. shape (nComponents, )
+    w*: Vector              ## Weigths for linear term, shape (nFeatures)
+    intercept*: float64     # Intercept term
+
+  ConvexFactorizationMachine* = ref ConvexFactorizationMachineObj
+
+
+proc newConvexFactorizationMachine*(
+  task: TaskKind, maxComponents = 30, alpha0 = 1e-6, alpha = 1e-3,
+  beta = 1e-5, loss = SquaredHinge, fitIntercept = true, fitLinear = true,
+  ignoreDiag=true, warmStart = false): ConvexFactorizationMachine =
+  ## Create a new ConvexFactorizationMachine.
+  ## task: classification or regression.
+  ## maxComponents: Maximum number of basis vectors.
+  ## alpha0: Regularization strength for intercept.
+  ## alpha: Regularization strength for linear term.
+  ## beta: Regularization strength for higher-order weights.
+  ## loss: Loss function.
+  ##   - Squared: 1/2 (y-p)**2,
+  ##   - SquaredHinge: (max(0, 1-y*p))**2,
+  ##   - Logistic: log (1+exp(-y*p)), where p is the predicted value.
+  ## fitIntercept: Whether to fit intercept (a.k.a bias) term or not.
+  ## fitLinear: Whether to fit linear term or not.
+  ## warmStart: Whether to do warwm start fitting or not.
+  new(result)
+  result.task = task
+  result.degree = 2
+  if maxComponents < 1:
+    raise newException(ValueError, "maxComponents < 1.")
+  result.maxComponents = maxComponents
+  if alpha0 < 0 or alpha < 0 or beta < 0:
+    raise newException(ValueError, "Regularization strength < 0.")
+  result.alpha0 = alpha0
+  result.alpha = alpha
+  result.beta = beta
+  case task
+  of regression: result.loss = Squared
+  of classification: result.loss = loss
+  result.fitIntercept = fitIntercept
+  result.fitLinear = fitLinear
+  result.ignoreDiag = ignoreDiag
+  result.warmStart = warmStart
+  result.degree = 2
+  result.isInitalized = false
+  result.lams = zeros([0])
+
+
+proc init*[Dataset](self: ConvexFactorizationMachine, X: Dataset, force=false) =
+  ## Initializes the factorization machine.
+  ## If force=false, fm is already initialized, and warmStart=true,
+  ## fm will not be initialized.
+  if force or not (self.warmStart and self.isInitalized):
+    let nFeatures: int = X.nFeatures
+    self.w = zeros([nFeatures])
+    self.P = zeros([0, nFeatures])
+    self.intercept = 0.0
+  self.isInitalized = true
+
+
+proc decisionFunction*[Dataset](self: ConvexFactorizationMachine, 
+                                X: Dataset): seq[float64] =
+  ## Returns the model outputs as seq[float64].
+  self.checkInitialized()
+  let nSamples: int = X.nSamples
+  let nFeatures = X.nFeatures
+  var A = zeros([nSamples, 3])
+  result = newSeqWith(nSamples, 0.0)
+
+  linear(X, self.w, result)
+  for i in 0..<nSamples:
+    result[i] += self.intercept
+
+  if (nFeatures != self.P.shape[1]):
+    raise newException(ValueError, "Invalid nFeatures.")
+  for s in 0..<self.P.shape[0]:
+    if self.ignoreDiag:
+      anova(X, self.P, A, 2, s, 0)
+    else:
+      poly(X, self.P, A, 2, s, 0)
+    for i in 0..<nSamples:
+      result[i] += self.lams[s]*A[i, 2]
+
+
+proc dump*(self: ConvexFactorizationMachine, fname: string) =
+  ## Dumps the fitted factorization machine.
+  self.checkInitialized()
+  let nComponents = self.P.shape[0]
+  let nFeatures = self.P.shape[1]
+  var f: File = open(fname, fmWrite)
+  f.writeLine("task: ", $self.task)
+  f.writeLine("nFeatures: ", nFeatures)
+  f.writeLine("degree: ", 2)
+  f.writeLine("nComponents: ", self.P.shape[0])
+  f.writeLine("maxComponents: ", self.maxComponents)
+  f.writeLine("alpha0: ", self.alpha0)
+  f.writeLine("alpha: ", self.alpha)
+  f.writeLine("beta: ", self.beta)
+  f.writeLine("loss: ", self.loss)
+  f.writeLine("fitIntercept: ", self.fitIntercept)
+  f.writeLine("fitLinear: ", self.fitLinear)
+  f.writeLine("randomState: ", self.randomState)
+  var params: seq[float64] = newSeq[float64](nFeatures)
+  f.writeLine("P:")
+  for s in 0..<nComponents:
+    for j in 0..<nFeatures:
+      params[j] = self.P[s, j]
+    f.writeLine(params.join(" "))
+  f.writeLine("w:")
+  for j in 0..<nFeatures:
+    params[j] = self.w[j]
+  f.writeLine(params.join(" "))
+  f.writeLine("intercept: ", self.intercept)
+  f.close()
+
+
+proc load*(fm: var ConvexFactorizationMachine, fname: string, warmStart: bool)=
+  ## Loads the fitted convex factorization machine.
+  new(fm)
+  var f: File = open(fname, fmRead)
+  var nFeatures: int
+  var nComponents: int
+  fm.task = parseEnum[TaskKind](f.readLine().split(" ")[1])
+  discard parseInt(f.readLine().split(" ")[1], nFeatures, 0)
+  discard parseInt(f.readLine().split(" ")[1], nComponents, 0)
+  discard parseInt(f.readLine().split(" ")[1], fm.maxComponents, 0)
+  discard parseFloat(f.readLine().split(" ")[1], fm.alpha0, 0)
+  discard parseFloat(f.readLine().split(" ")[1], fm.alpha, 0)
+  discard parseFloat(f.readLine().split(" ")[1], fm.beta, 0)
+  fm.loss = parseEnum[LossFunctionKind](f.readLine().split(" ")[1])
+  fm.fitIntercept = parseBool(f.readLine().split(" ")[1])
+  fm.fitLinear = parseBool(f.readLine().split(" ")[1])
+  fm.warmStart = warmStart
+  discard parseInt(f.readLine().split(" ")[1], fm.randomState, 0)
+
+  var i = 0
+  var val: float64
+  fm.P = zeros([nComponents, nFeatures])
+  discard f.readLine() # read "P[order]:" and discard it
+  for s in 0..<nComponents:
+    let line = f.readLine()
+    var i = 0
+    var val: float64
+    for j in 0..<nFeatures:
+      i.inc(parseFloat(line, val, i))
+      i.inc()
+      fm.P[s, j] = val
+  fm.w = zeros([nFeatures])
+  discard f.readLine()
+  let line = f.readLine()
+  i = 0
+  for j in 0..<nFeatures:
+    i.inc(parseFloat(line, val, i))
+    i.inc()
+    fm.w[j] = val
+  discard parseFloat(f.readLine().split(" ")[1], fm.intercept, 0)
+  f.close()
+  fm.isInitalized = true

--- a/src/nimfm/dataset.nim
+++ b/src/nimfm/dataset.nim
@@ -1,4 +1,4 @@
-import sequtils, sugar, parseutils, math, os, strformat
+import sequtils, sugar, parseutils, math, os, strformat, random
 
 
 const Numbers = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
@@ -22,6 +22,9 @@ type
 
   NormKind* = enum
     l1, l2, linfty
+
+
+func shape*(self: BaseDataset): array[2, int] = [self.nSamples, self.nFeatures]
 
 
 func nnz*(self: BaseDataset): int =
@@ -187,9 +190,27 @@ func `[]`*(X: CSCDataset, slice: HSlice[int, BackwardsIndex]): CSCDataset =
   result = X[slice.a..(X.nSamples-int(slice.b))]
 
 
+func shuffle*[T](X: CSRDataset, y: seq[T]):
+                 tuple[XShuffled: CSRDataset, yShuffled: seq[T]] =
+  ## Shuffles the dataset X and target y.
+  if len(y) != X.nSamples:
+    raise newException(ValueError, "X.nSamples != len(y)")
+  var indices = toSeq(0..<len(y))
+  var j, tmp: int
+  for i in 0..<len(y):
+    j = rand(len(y)-1-i)
+    tmp = indices[i]
+    indices[i] = indices[i+j]
+    indices[i+j] = tmp
+  result = shuffle(X, y, indices)
+
+
 func shuffle*[T](X: CSRDataset, y: seq[T], indices: openarray[int]):
                  tuple[XShuffled: CSRDataset, yShuffled: seq[T]] =
   ## Shuffles the dataset X and target y by using indices.
+  if len(y) != X.nSamples:
+    raise newException(ValueError, "X.nSamples != len(y)")
+
   var yShuffled = newSeq[T](len(indices))
   for ii, i in indices:
     yShuffled[ii] = y[i]

--- a/src/nimfm/extmath.nim
+++ b/src/nimfm/extmath.nim
@@ -1,0 +1,147 @@
+import strformat, math
+import tensor, dataset
+
+
+proc matmul*(D: Matrix, S: CSRDataset, R: var Matrix) =
+  if D.shape[1] != S.nSamples:
+    let msg = fmt"D.shape[1] {D.shape[1]} != nSamples {S.nSamples}."
+    raise newException(ValueError, msg)
+
+  R[0..^1, 0..^1] = 0.0
+  for m in 0..<D.shape[0]:
+    for i in 0..<S.nSamples:
+      for (j, val) in S.getRow(i):
+        R[m, j] += D[m, i] * val
+      
+
+proc matmul*(D: Matrix, S: CSCDataset, R: var Matrix) =
+  if D.shape[1] != S.nSamples:
+    let msg = fmt"D.shape[1] {D.shape[1]} != nSamples {S.nSamples}."
+    raise newException(ValueError, msg)
+
+  R[0..^1, 0..^1] = 0.0
+  for m in 0..<D.shape[0]:
+    for j in 0..<S.nFeatures:
+      for (i, val) in S.getCol(j):
+        R[m, j] += D[m, i] * val
+ 
+
+proc matmul*(S: CSRDataset, D: Matrix, R: var Matrix) =
+  if D.shape[0] != S.nSamples:
+    let msg = fmt"nFeatures {S.nFeatures} != D.shape[0] {D.shape[0]}."
+    raise newException(ValueError, msg) 
+  R[0..^1, 0..^1] = 0.0
+
+  for i in 0..<S.nSamples:
+    for (j, val) in S.getRow(i):
+      for n in 0..<D.shape[1]:
+        R[i, n] += val * D[j, n]
+
+
+proc matmul*(S: CSCDataset, D: Matrix, R: var Matrix) =
+  if D.shape[0] != S.nSamples:
+    let msg = fmt"nFeatures {S.nFeatures} != D.shape[0] {D.shape[0]}."
+    raise newException(ValueError, msg) 
+
+  R[0..^1, 0..^1] = 0.0
+  for j in 0..<S.nFeatures:
+    for (i, val) in S.getCol(j):
+      for n in 0..<D.shape[1]:
+        R[i, n] += val * D[j, n]
+
+
+proc matmul*[T: CSRDataset|CSCDataset](D: Matrix, S: T): Matrix =
+  new(result)
+  result = zeros([D.shape[0], S.nFeatures])
+  matmul(D, S, result)
+
+
+proc matmul*[T: CSRDataset|CSCDataset](S: T, D: Matrix): Matrix =
+  new(result)
+  result = zeros([S.nSamples, D.shape[1]])
+  matmul(S, D, result)
+
+
+proc mvmul*(S: CSRDataset, vec: Vector, result: var Vector) =
+  if S.nFeatures != len(vec):
+    let msg = fmt"nFeatures {S.nFeatures} != len(vec){len(vec)}."
+    raise newException(ValueError, msg)
+
+  for i in 0..<S.nSamples:
+    result[i] = 0.0
+    for (j, val) in S.getRow(i):
+      result[i] += val * vec[j]
+
+
+proc mvmul*(S: CSCDataset, vec: Vector, result: var Vector) =
+  if S.nFeatures != len(vec):
+    let msg = fmt"nFeatures {S.nFeatures} != len(vec){len(vec)}."
+    raise newException(ValueError, msg)
+
+  result[0..^1] = 0.0
+  for j in 0..<S.nFeatures:
+    for (i, val) in S.getCol(j):
+      result[i] += val * vec[j]
+
+
+proc vmmul*(vec: Vector, S: CSRDataset, result: var Vector) =
+  if S.nSamples != len(vec):
+    let msg = fmt"len(vec){len(vec)} != nSamples {S.nSamples}."
+    raise newException(ValueError, msg)
+
+  result[0..^1] = 0.0
+  for i in 0..<S.nSamples:
+    for (j, val) in S.getRow(i):
+      result[j] += val * vec[i]
+
+
+proc vmmul*(vec: Vector, S: CSCDataset, result: var Vector) =
+  if S.nSamples != len(vec):
+    let msg = fmt"len(vec){len(vec)} != nSamples {S.nSamples}."
+    raise newException(ValueError, msg)
+
+  for j in 0..<S.nFeatures:
+    result[j] = 0
+    for (i, val) in S.getCol(j):
+      result[j] += val * vec[i]
+
+
+proc mvmul*[T: CSRDataset|CSCDataset](S: T, vec: Vector): Vector =
+  result = zeros([S.nSamples])
+  mvmul(S, vec, result)
+
+
+proc vmmul*[T: CSRDataset|CSCDataset](vec: Vector, S: T): Vector =
+  result = zeros([S.nFeatures])
+  vmmul(vec, S, result)
+
+
+proc norm*(X: CSRDataset, p=1, axis=0): Vector =
+  if axis == 0:
+    result = zeros([X.nFeatures])
+    for i in 0..<X.nSamples:
+      for (j, val) in X.getRow(i):
+        result[j] += val ^ p
+  elif axis == 1:
+    result = zeros([X.nSamples])
+    for i in 0..<X.nSamples:
+      for (j, val) in X.getRow(i):
+        result[i] += val ^ p
+  for i in 0..<len(result):
+    result[i] = pow(result[i], 1.0 / float(p))
+
+
+proc norm*(X: CSCDataset, p=1, axis=0): Vector =
+  if axis == 0:
+    result = zeros([X.nFeatures])
+    for j in 0..<X.nFeatures:
+      for (i, val) in X.getCol(j):
+        result[j] += val ^ p
+  elif axis == 1:
+    result = zeros([X.nSamples])
+    for j in 0..<X.nFeatures:
+      for (i, val) in X.getCol(j):
+        result[i] += val ^ p
+  for i in 0..<len(result):
+    result[i] = pow(result[i], 1.0 / float(p))
+  

--- a/src/nimfm/fm_base.nim
+++ b/src/nimfm/fm_base.nim
@@ -1,0 +1,48 @@
+import sequtils, math, sugar, utils
+import metrics
+
+
+type
+  TaskKind* = enum
+    regression = "r",
+    classification = "c"
+
+  NotFittedError = object of Exception
+
+
+proc checkInitialized*[FM](self: FM) =
+  if not self.isInitalized:
+    raise newException(NotFittedError, "Factorization machines is not fitted.")
+
+
+proc predict*[Dataset, FM](self: FM, X: Dataset): seq[int] =
+  ## Returns the sign vector of the model outputs as seq[int].
+  result = self.decisionFunction(X).map(x=>sgn(x))
+
+
+proc predictProba*[Dataset, FM](self: FM, X: Dataset): seq[float64] =
+  ## Returns probabilities that each instance belongs to positive class.
+  ## It shoud be used only when task=classification.
+  result = self.decisionFunction(X).map(expit)
+
+
+proc checkTarget*[FM](self: FM, y: seq[SomeNumber]): seq[float64] =
+  ## Transforms targets vector to float for regression or
+  ## to sign for classification.
+  case self.task
+  of classification:
+    result = y.map(x => float(sgn(x)))
+  of regression:
+    result = y.map(x => float(x))
+
+
+proc score*[FM, Dataset](self: FM, X: Dataset, y: seq[float64]): float64 =
+  ## Returns the score between the model outputs and true targets.
+  ## Computes root mean squared error when task=regression (lower is better).
+  ## Computes accuracy when task=classification (higher is better). 
+  let yPred = self.decisionFunction(X)
+  case self.task
+  of regression:
+    result = rmse(y, yPred)
+  of classification:
+    result = accuracy(y.map(x=>sgn(x)), yPred.map(x=>sgn(x)))

--- a/src/nimfm/kernels.nim
+++ b/src/nimfm/kernels.nim
@@ -74,22 +74,21 @@ proc anova*(X: CSRDataset, P: Matrix, A: var Matrix,
   else:
     for i in 0..<nSamples:
       for (j, val) in X.getRow(i):
-        A[i, 2] += P[s, j] * val
-        A[i, 1] += (P[s, j] * val)^2
+        A[i, 1] += P[s, j] * val
+        A[i, 2] += (P[s, j] * val)^2
       # for augmented features
       for j in nFeatures..<(nFeatures+nAugments):
-        A[i, 2] += P[s, j]
-        A[i, 1] += P[s, j]^2
-      A[i, 2] = (A[i, 2]^2 - A[i, 1])/2.0
+        A[i, 1] += P[s, j]
+        A[i, 2] += P[s, j]^2
+      A[i, 2] = (A[i, 1]^2 - A[i, 2])/2.0
 
 
 proc poly*(X: CSCDataset, P: Matrix, A: var Matrix,  
            degree, s: int, nAugments: int = 0) =
   let nSamples = X.nSamples
   let nFeatures = X.nFeatures
-  for i in 0..<nSamples:
-    A[i, 0] = 1.0
-
+  A[0..^1, 1..^1] = 0.0
+  A[0..^1, 0] = 1.0
   for j in 0..<nFeatures:
     for (i, val) in X.getCol(j):
         A[i, 1] += P[s, j] * val
@@ -101,16 +100,17 @@ proc poly*(X: CSCDataset, P: Matrix, A: var Matrix,
     
   for i in 0..<nSamples:
     for order in 2..<degree+1:
-      A[i, order] = A[i, 1]^order
+      A[i, order] = A[i, order-1]*A[i, 1]
 
 
 proc poly*(X: CSRDataset, P: Matrix, A: var Matrix, 
             degree, s: int, nAugments: int = 0) =
   let nSamples = X.nSamples
   let nFeatures = X.nFeatures
-  for i in 0..<nSamples:
-    A[i, 0] = 1.0
-  
+
+  A[0..^1, 0..^1] = 0.0
+  A[0..^1, 0] = 1.0
+
   for i in 0..<nSamples:
     for (j, val) in X.getRow(i):
       A[i, 1] += P[s, j] * val
@@ -120,4 +120,4 @@ proc poly*(X: CSRDataset, P: Matrix, A: var Matrix,
   
   for i in 0..<nSamples:
     for order in 2..<degree+1:
-      A[i, order] = A[i, 1]^order
+      A[i, order] = A[i, order-1]*A[i, 1]

--- a/src/nimfm/kernels.nim
+++ b/src/nimfm/kernels.nim
@@ -1,6 +1,7 @@
 import dataset, tensor, math
 
-proc linear*(X: CSCDataset, w: Vector,  kernel: var seq[float64]) =
+
+proc linear*[T, U](X: CSCDataset, w: T, kernel: var U) =
   let nFeatures = X.nFeatures
   let nSamples = X.nSamples
   for i in 0..<nSamples:
@@ -10,7 +11,7 @@ proc linear*(X: CSCDataset, w: Vector,  kernel: var seq[float64]) =
       kernel[i] += val * w[j]
 
 
-proc linear*(X: CSRDataset, w: Vector, kernel: var seq[float64]) =
+proc linear*[T, U](X: CSRDataset, w: T, kernel: var U) =
   let nSamples = X.nSamples
   for i in 0..<nSamples:
     kernel[i] = 0.0
@@ -18,8 +19,8 @@ proc linear*(X: CSRDataset, w: Vector, kernel: var seq[float64]) =
       kernel[i] += w[j] * val
 
 
-proc anova*(X: CSCDataset, P: Tensor, A: var Matrix,  
-            degree, order, s: int, nAugments: int = 0) =
+proc anova*(X: CSCDataset, P: Matrix, A: var Matrix,  
+            degree, s: int, nAugments: int = 0) =
   let nSamples = X.nSamples
   let nFeatures = X.nFeatures
   for i in 0..<nSamples:
@@ -31,28 +32,29 @@ proc anova*(X: CSCDataset, P: Tensor, A: var Matrix,
     for j in 0..<nFeatures:
       for (i, val) in X.getCol(j):
         for t in 0..<degree:
-          A[i, degree-t] += A[i, degree-t-1] * P[order, s, j] * val
+          A[i, degree-t] += A[i, degree-t-1] * P[s, j] * val
     # for augmented features
     for j in nFeatures..<(nFeatures+nAugments):
       for i in 0..<nSamples:
         for t in 0..<degree:
-          A[i, degree-t] += A[i, degree-t-1] * P[order, s, j]
+          A[i, degree-t] += A[i, degree-t-1] * P[s, j]
   else:
     for j in 0..<nFeatures:
       for (i, val) in X.getCol(j):
-        A[i, 1] += P[order, s, j] * val
-        A[i, 2] += (P[order, s, j]*val)^2
+        A[i, 1] += P[s, j] * val
+        A[i, 2] += (P[s, j]*val)^2
     # for augmented features
     for j in nFeatures..<(nFeatures+nAugments):
       for i in 0..<nSamples:
-        A[i, 1] += P[order, s, j]
-        A[i, 2] += P[order, s, j]^2
+        A[i, 1] += P[s, j]
+        A[i, 2] += P[s, j]^2
+    # finalize
     for i in 0..<nSamples:
       A[i, 2] = (A[i, 1]^2 - A[i, 2])/2.0
 
 
-proc anova*(X: CSRDataset, P: Tensor, A: var Matrix, 
-            degree, order, s: int, nAugments: int = 0) =
+proc anova*(X: CSRDataset, P: Matrix, A: var Matrix, 
+            degree, s: int, nAugments: int = 0) =
   let nSamples = X.nSamples
   let nFeatures = X.nFeatures
   for i in 0..<nSamples:
@@ -64,18 +66,58 @@ proc anova*(X: CSRDataset, P: Tensor, A: var Matrix,
     for i in 0..<nSamples:
       for (j, val) in X.getRow(i):
         for t in 0..<degree:
-          A[i, degree-t] += A[i, degree-t-1] * P[order, s, j] * val
+          A[i, degree-t] += A[i, degree-t-1] * P[s, j] * val
       # for augmented features
       for j in nFeatures..<(nFeatures+nAugments):
         for t in 0..<degree:
-          A[i, degree-t] += A[i, degree-t-1] * P[order, s, j]
+          A[i, degree-t] += A[i, degree-t-1] * P[s, j]
   else:
     for i in 0..<nSamples:
       for (j, val) in X.getRow(i):
-        A[i, 2] += P[order, s, j] * val
-        A[i, 1] += (P[order, s, j] * val)^2
+        A[i, 2] += P[s, j] * val
+        A[i, 1] += (P[s, j] * val)^2
       # for augmented features
       for j in nFeatures..<(nFeatures+nAugments):
-        A[i, 2] += P[order, s, j]
-        A[i, 1] += P[order, s, j]^2
+        A[i, 2] += P[s, j]
+        A[i, 1] += P[s, j]^2
       A[i, 2] = (A[i, 2]^2 - A[i, 1])/2.0
+
+
+proc poly*(X: CSCDataset, P: Matrix, A: var Matrix,  
+           degree, s: int, nAugments: int = 0) =
+  let nSamples = X.nSamples
+  let nFeatures = X.nFeatures
+  for i in 0..<nSamples:
+    A[i, 0] = 1.0
+
+  for j in 0..<nFeatures:
+    for (i, val) in X.getCol(j):
+        A[i, 1] += P[s, j] * val
+
+  # for augmented features
+  for j in nFeatures..<(nFeatures+nAugments):
+    for i in 0..<nSamples:
+        A[i, 1] += P[s, j]
+    
+  for i in 0..<nSamples:
+    for order in 2..<degree+1:
+      A[i, order] = A[i, 1]^order
+
+
+proc poly*(X: CSRDataset, P: Matrix, A: var Matrix, 
+            degree, s: int, nAugments: int = 0) =
+  let nSamples = X.nSamples
+  let nFeatures = X.nFeatures
+  for i in 0..<nSamples:
+    A[i, 0] = 1.0
+  
+  for i in 0..<nSamples:
+    for (j, val) in X.getRow(i):
+      A[i, 1] += P[s, j] * val
+    # for augmented features
+    for j in nFeatures..<(nFeatures+nAugments):
+      A[i, 1] += P[s, j]
+  
+  for i in 0..<nSamples:
+    for order in 2..<degree+1:
+      A[i, order] = A[i, 1]^order

--- a/src/nimfm/loss.nim
+++ b/src/nimfm/loss.nim
@@ -22,7 +22,7 @@ proc newLossFunction*(kind: LossFunctionKind): LossFunction =
   result = LossFunction(kind: kind, mu: mu)
 
 
-proc loss*(lossFunc: LossFunction, p, y: float64): float64 =
+proc loss*(lossFunc: LossFunction, y, p: float64): float64 =
   case lossFunc.kind
   of Squared: return 0.5 * (p-y)^2
   of SquaredHinge:
@@ -39,7 +39,7 @@ proc loss*(lossFunc: LossFunction, p, y: float64): float64 =
       return ln(exp(z)+1) - z
 
 
-proc dloss*(lossFunc: LossFunction, p, y: float64): float64 =
+proc dloss*(lossFunc: LossFunction, y, p: float64): float64 =
   case lossFunc.kind
   of Squared: return p-y
   of SquaredHinge:

--- a/src/nimfm/loss.nim
+++ b/src/nimfm/loss.nim
@@ -1,54 +1,102 @@
 import math
 
 type
-  LossFunctionKind* = enum
-    Squared = "Squared",
-    SquaredHinge = "SquaredHinge",
-    Logistic = "Logistic"
+  Squared* = ref object
 
-  LossFunctionObj* = object of RootObj
-    kind: LossFunctionKind
-    mu*: float64
+  SquaredHinge* = ref object
 
-  LossFunction* = ref LossFunctionObj
+  Logistic* = ref object
 
 
-proc newLossFunction*(kind: LossFunctionKind): LossFunction =
-  var mu: float64
-  case kind
-  of Squared: mu = 1.0
-  of SquaredHinge: mu = 2.0
-  of Logistic: mu = 0.25
-  result = LossFunction(kind: kind, mu: mu)
+  Huber* = ref object
+    threshold: float64
 
 
-proc loss*(lossFunc: LossFunction, y, p: float64): float64 =
-  case lossFunc.kind
-  of Squared: return 0.5 * (p-y)^2
-  of SquaredHinge:
-    let z = 1 - p*y
-    if z > 0:
-      return z*z
-    else:
-      return 0
-  of Logistic:
-    let z = p*y
-    if z > 0:
-      return ln(1+exp(-z))
-    else:
-      return ln(exp(z)+1) - z
+proc newSquared*(): Squared = new(Squared)
 
 
-proc dloss*(lossFunc: LossFunction, y, p: float64): float64 =
-  case lossFunc.kind
-  of Squared: return p-y
-  of SquaredHinge:
-    let z = 1 - p*y
-    if z > 0: return -2 * y * z
-    else: return 0
-  of Logistic:
-    let z = p * y
-    if z > 0:
-      return -y * exp(-z) / (1+exp(-z))
-    else:
-      return y*exp(z)/(exp(z)+1) - y
+proc loss*(self: Squared, y, p: float64): float64 = 0.5 * (y-p)^2
+
+
+proc dloss*(self: Squared, y, p: float64): float64 = p-y
+
+
+proc ddloss*(self: Squared, y, p: float64): float64 = 1.0
+
+
+proc mu*(self: Squared): float64 = 1.0
+
+
+proc newSquaredHinge*(): SquaredHinge = new(SquaredHinge)
+
+
+proc loss*(self: SquaredHinge, y, p: float64): float64 = max(1-p*y, 0)^2
+
+
+proc dloss*(self: SquaredHinge, y, p: float64): float64 =
+  let z = 1-p*y
+  if z > 0: result = -2*y*z
+  else: result = 0.0
+
+
+proc ddloss*(self: SquaredHinge, y, p: float64): float64 =
+  let z = 1-p*y
+  if z > 0: result = 2.0
+  else: result = 0.0
+
+
+proc mu*(self: SquaredHinge): float64 = 2.0
+
+
+proc newLogistic*(): Logistic = new(Logistic)
+
+
+proc loss*(self: Logistic, y, p: float64): float64 =
+  let z = p * y
+  if z > 0:
+    result = ln(1+exp(-z))
+  else:
+    result = ln(exp(z)+1) - z
+
+
+proc dloss*(self: Logistic, y, p: float64): float64 =
+  let z = p * y
+  if z > 0:
+    result =  -y * exp(-z) / (1+exp(-z))
+  else:
+    result =  -y / (exp(z)+1)
+
+
+proc ddloss*(self: Logistic, y, p: float64): float64 =
+  let z = p*y
+  if z > 0:
+    result =  exp(-z) / ((1+exp(-z))^2)
+  else:
+    result = exp(z) / ((1+exp(z))^2)
+
+
+proc mu*(self: Logistic): float64 = 0.25
+
+
+proc newHuber*(threshold=1.0): Huber = Huber(threshold: threshold)
+
+
+proc loss*(self: Huber, y, p: float64): float64 =
+  let z = abs(y - p)
+  if z < self.threshold: result = 0.5 * z^2
+  else: result = self.threshold * (z - 0.5*self.threshold)
+
+
+proc dloss*(self: Huber, y, p: float64): float64 =
+  let z = abs(y-p)
+  if z < self.threshold: result = y - p
+  else: result = self.threshold
+
+
+proc ddloss*(self: Huber, y, p: float64): float64 =
+  let z = abs(y-p)
+  if z < self.threshold: result = 1.0
+  else: result = 0.0
+
+
+proc mu*(self: Huber): float64 = 1.0

--- a/src/nimfm/modules.nim
+++ b/src/nimfm/modules.nim
@@ -1,0 +1,9 @@
+import factorization_machine,
+       convex_factorization_machine,
+       fm_base, loss, dataset, metrics, tensor,
+       optimizers/optimizers
+
+export factorization_machine,
+       convex_factorization_machine,
+       fm_base, loss, dataset, metrics, tensor,
+       optimizers

--- a/src/nimfm/optimizers/coordinate_descent.nim
+++ b/src/nimfm/optimizers/coordinate_descent.nim
@@ -1,5 +1,6 @@
 import ../loss, ../dataset, ../tensor, ../kernels, ../factorization_machine
-import fit_linear, base
+import ../fm_base
+import fit_linear, optimizer_base
 import sequtils, math, strformat, strutils
 
 type
@@ -7,7 +8,7 @@ type
     ## Coordinate descent solver.
 
 
-proc newCoordinateDescent*(maxIter = 100, verbose = true, tol = 1e-3):
+proc newCoordinateDescent*(maxIter = 100, verbose = 1, tol = 1e-3):
                            CoordinateDescent =
   ## Creates new CoordinateDescent.
   ## maxIter: Maximum number of iteration. In one iteration. \
@@ -31,7 +32,7 @@ proc update(psj: float64, X: CSCDataset, y: seq[float64], yPred: seq[float64],
   var invStepSize: float64 = 0.0
   for (i, val) in X.getCol(j):
     computeDerivative(dA, A, psj, val, i, degree)
-    result += loss.dloss(yPred[i], y[i]) * dA[degree-1]
+    result += loss.dloss(y[i], yPred[i]) * dA[degree-1]
     invStepSize += dA[degree-1]^2
 
   invStepSize = invStepSize*loss.mu + beta
@@ -46,7 +47,7 @@ proc updateAug(psj: float64, y, yPred: seq[float64], beta: float64,
   var invStepSize = 0.0
   for i in 0..<nSamples:
     computeDerivative(dA, A, psj, 1.0, i, degree)
-    result += loss.dloss(yPred[i], y[i]) * dA[degree-1]
+    result += loss.dloss(y[i], yPred[i]) * dA[degree-1]
     invStepSize += dA[degree-1]^2
 
   invStepSize = invStepSize*loss.mu + beta
@@ -54,17 +55,17 @@ proc updateAug(psj: float64, y, yPred: seq[float64], beta: float64,
 
 
 proc epoch(X: CSCDataset, y: seq[float64], yPred: var seq[float64],
-           P: var Tensor, beta: float64, degree, order, nAugments: int,
+           P: var Matrix, beta: float64, degree, nAugments: int,
            loss: LossFunction, A: var Matrix, dA: var Vector): float64 =
   result = 0.0
   let nFeatures = X.nFeatures
-  let nComponents = P.shape[1]
+  let nComponents = P.shape[0]
   let nSamples = X.nSamples
   for s in 0..<nComponents:
     # compute cache
-    anova(X, P, A, degree, order, s, nAugments)
+    anova(X, P, A, degree, s, nAugments)
     for j in 0..<nFeatures:
-      var psj = P[order, s, j]
+      var psj = P[s, j]
       let update = update(psj, X, y, yPred, beta, degree, j, loss, A, dA)
       result += abs(update)
       # synchronize
@@ -75,48 +76,48 @@ proc epoch(X: CSCDataset, y: seq[float64], yPred: var seq[float64],
           A[i, deg] -= update * dA[deg-1]
         A[i, degree] -= update * dA[degree-1]
         yPred[i] -= update * dA[degree-1]
-      P[order, s, j] -= update
+      P[s, j] -= update
 
     # for augmented features
     for j in nFeatures..<(nFeatures+nAugments):
-      var psj = P[order, s, j]
+      var psj = P[s, j]
       let update = updateAug(psj, y, yPred, beta, degree, j, loss, A, dA)
       result += abs(update)
       # synchronize
       for i in 0..<nSamples:
         dA[0] = 1.0
         for deg in 1..<degree:
-          dA[deg] = A[i, deg] - P[order, s, j]*dA[deg-1]
+          dA[deg] = A[i, deg] - P[s, j]*dA[deg-1]
           A[i, deg] -= update * dA[deg-1]
         A[i, degree] -= update * dA[degree-1]
         yPred[i] -= update * dA[degree-1]
-      P[order, s, j] -= update
+      P[s, j] -= update
 
 
 # optimized for degree=2, faster than above epoch proc
 proc epochDeg2(X: CSCDataset, y: seq[float64], yPred: var seq[float64],
-               P: var Tensor, beta: float64, order, nAugments: int,
+               P: var Matrix, beta: float64, nAugments: int,
                loss: LossFunction, cacheDeg2: var Vector): float64 =
   result = 0.0
   let nFeatures = X.nFeatures
-  let nComponents = P.shape[1]
+  let nComponents = P.shape[0]
   let nSamples = X.nSamples
   for s in 0..<nComponents:
     # compute cache. cacheDeg2[i] = \langle p_{s}, x_i \rangle
     for i in 0..<nSamples:
       cacheDeg2[i] = 0
-      if nAugments == 1: cacheDeg2[i] = P[order, s, nFeatures]
+      if nAugments == 1: cacheDeg2[i] = P[s, nFeatures]
     for j in 0..<nFeatures:
       for (i, val) in X.getCol(j):
-        cacheDeg2[i] += val * P[order, s, j]
+        cacheDeg2[i] += val * P[s, j]
 
     for j in 0..<nFeatures:
-      var psj = P[order, s, j]
+      var psj = P[s, j]
       var update = beta * psj
       var invStepSize = 0.0
       for (i, val) in X.getCol(j):
         let dA = (cacheDeg2[i] - psj * val) * val
-        update += loss.dloss(yPred[i], y[i]) * dA
+        update += loss.dloss(y[i], yPred[i]) * dA
         invStepSize += dA^2
       invStepSize = invStepSize*loss.mu + beta
       if invStepSize < 1e-12: 
@@ -127,16 +128,16 @@ proc epochDeg2(X: CSCDataset, y: seq[float64], yPred: var seq[float64],
       for (i, val) in X.getCol(j):
         yPred[i] -= update * (cacheDeg2[i] - psj * val) * val
         cacheDeg2[i] -= update * val
-      P[order, s, j] -= update
+      P[s, j] -= update
 
     # for augmented features
     if nAugments == 1:
-      var psj = P[order, s, nFeatures]
+      var psj = P[s, nFeatures]
       var update = beta * psj
       var invStepSize = 0.0
       for i in 0..<nSamples:
         let dA = (cacheDeg2[i] - psj)
-        update += loss.dloss(yPred[i], y[i]) * dA
+        update += loss.dloss(y[i], yPred[i]) * dA
         invStepSize += dA^2
       invStepSize = invStepSize*loss.mu + beta
       update /= invStepSize
@@ -145,7 +146,7 @@ proc epochDeg2(X: CSCDataset, y: seq[float64], yPred: var seq[float64],
       for i in 0..<nSamples:
         yPred[i] -= update * (cacheDeg2[i] - psj)
         cacheDeg2[i] -= update
-      P[order, s, nFeatures] -= update
+      P[s, nFeatures] -= update
 
 
 proc fit*(self: CoordinateDescent, X: CSCDataset, y: seq[float64],
@@ -190,7 +191,7 @@ proc fit*(self: CoordinateDescent, X: CSCDataset, y: seq[float64],
 
   for order in 0..<nOrders:
     for s in 0..<nComponents:
-      anova(X, fm.P, A, degree-order, order, s, nAugments)
+      anova(X, fm.P[order], A, degree-order, s, nAugments)
       for i in 0..<nSamples:
         yPred[i] += A[i, degree-order]
   
@@ -205,16 +206,16 @@ proc fit*(self: CoordinateDescent, X: CSCDataset, y: seq[float64],
     
     for order in 0..<nOrders:
       if (degree-order) > 2:
-        viol += epoch(X, y, yPred, fm.P, beta, degree-order, order, nAugments,
+        viol += epoch(X, y, yPred, fm.P[order], beta, degree-order, nAugments,
                       loss, A, dA)
       else:
-        viol += epochDeg2(X, y, yPred, fm.P, beta, order, nAugments, loss,
+        viol += epochDeg2(X, y, yPred, fm.P[order], beta, nAugments, loss,
                           cacheDeg2)
 
-    if self.verbose:
+    if self.verbose > 0:
       var meanLoss = 0.0
       for i in 0..<nSamples:
-        meanLoss += loss.loss(yPred[i], y[i])
+        meanLoss += loss.loss(y[i], yPred[i])
       meanLoss /= float(nSamples)
       stdout.write(fmt"Iteration: {align($(it+1), len($self.maxIter))}")
       stdout.write(fmt"   Violation: {viol:1.4e}")
@@ -223,8 +224,8 @@ proc fit*(self: CoordinateDescent, X: CSCDataset, y: seq[float64],
       stdout.flushFile()
 
     if viol < self.tol:
-      if self.verbose: echo("Converged at iteration ", it, ".")
+      if self.verbose > 0: echo("Converged at iteration ", it+1, ".")
       isConverged = true
       break
-  if not isConverged and self.verbose:
+  if not isConverged and self.verbose > 0:
     echo("Objective did not converge. Increase maxIter.")

--- a/src/nimfm/optimizers/fit_linear.nim
+++ b/src/nimfm/optimizers/fit_linear.nim
@@ -12,7 +12,7 @@ proc fitLinearCD*(w: var Vector, X: CSCDataset, y: seq[float64],
   for j in 0..<nFeatures:
     update = alpha * w[j]
     for (i, val) in X.getCol(j):
-      update += loss.dloss(yPred[i], y[i]) * val
+      update += loss.dloss(y[i], yPred[i]) * val
     invStepSize = loss.mu * colNormSq[j] + alpha
     if invStepSize < 1e-12: 
       continue
@@ -28,7 +28,7 @@ proc fitInterceptCD*(intercept: var float64, y: seq[float64],
                      alpha0: float64, loss: LossFunction): float64 =
   result = alpha0 * intercept
   for i in 0..<nSamples:
-    result += loss.dloss(yPred[i], y[i])
+    result += loss.dloss(y[i], yPred[i])
   result /= loss.mu * float(nSamples) + alpha0
   intercept -= result
   for i in 0..<nSamples:

--- a/src/nimfm/optimizers/fit_linear.nim
+++ b/src/nimfm/optimizers/fit_linear.nim
@@ -1,8 +1,8 @@
-import ../loss, ../dataset, ../tensor
+import ../dataset, ../tensor
 
-proc fitLinearCD*(w: var Vector, X: CSCDataset, y: seq[float64],
-                  yPred: var seq[float64], colNormSq: Vector,
-                  alpha: float64, loss: LossFunction): float64 =
+proc fitLinearCD*[L](w: var Vector, X: CSCDataset, y: seq[float64],
+                     yPred: var seq[float64], colNormSq: Vector,
+                     alpha: float64, loss: L): float64 =
   result = 0.0
   let nFeatures = X.nFeatures
   var
@@ -23,9 +23,9 @@ proc fitLinearCD*(w: var Vector, X: CSCDataset, y: seq[float64],
       yPred[i] -= update * val
 
 
-proc fitInterceptCD*(intercept: var float64, y: seq[float64],
-                     yPred: var seq[float64], nSamples: int,
-                     alpha0: float64, loss: LossFunction): float64 =
+proc fitInterceptCD*[L](intercept: var float64, y: seq[float64],
+                        yPred: var seq[float64], nSamples: int,
+                        alpha0: float64, loss: L): float64 =
   result = alpha0 * intercept
   for i in 0..<nSamples:
     result += loss.dloss(y[i], yPred[i])

--- a/src/nimfm/optimizers/greedy_coordinate_descent.nim
+++ b/src/nimfm/optimizers/greedy_coordinate_descent.nim
@@ -1,77 +1,68 @@
-import ../loss, ../dataset, ../tensor, ../kernels
+import ../dataset, ../tensor, ../kernels, ../extmath
 import ../convex_factorization_machine
 from ../fm_base import checkTarget, checkInitialized
 import fit_linear, optimizer_base
-import sequtils, math, random, strformat, strutils
+import sequtils, math, strformat, strutils
 
 type
-  GreedyCoordinateDescent* = ref object of BaseCSCOptimizer
+  GreedyCD* = ref object of BaseCSCOptimizer
     ## Greedy coordinate descent solver for convex factorization machines.
-    ## In this solver, the regularization for interaction is not 
-    ## squared Frobenius norm for P but the trace norm for interaction weight
-    ## matrix.
+    ## In this solver, the regularization for P is not 
+    ## squared Frobenius norm but the trace norm for interaction weight
+    ## matrix (weight matrix for quadratic term).
     maxIterInner: int
     maxIterPower: int
     nRefitting: int
-    fullyRefit: bool
+    refitFully: bool
     tolPower: float64
+    sigma: float64
+    maxIterADMM: int
+    tolADMM: float64
+    maxIterLineSearch: int
 
 
-proc newGreedyCoordinateDescent*(
-  maxIter = 100, maxIterInner=100, nRefitting=10, fullyRefit=false,
-  verbose = 2, tol = 1e-7, maxIterPower = 100, tolPower = 1e-6):
-     GreedyCoordinateDescent =
-  ## Creates new GreedyCoordinateDescent for ConvexFactorizationMachine.
+proc newGreedyCD*(
+  maxIter = 10, maxIterInner=10, nRefitting=10, refitFully=false,
+  verbose = 1, tol = 1e-7, maxIterPower = 100, tolPower = 1e-7,
+  sigma=1e-4, maxIterADMM=100, tolADMM=1e-4,
+  maxIterLineSearch=100): GreedyCD =
+  ## Creates new GreedyCD for ConvexFactorizationMachine.
   ## maxIter: Maximum number of iteration for alternative optimization.
   ## maxIterInner: Maximum number of iteration for optimizing Z (P and lambda).
   ## maxIterPower: Maximum number of iteration for power iteration.
   ## nRefitting: Frequency of the refitting lams and P in inner loop.
   ##             If nRefitting > maxIterInner, lams and P are not reffitted.
-  ## fullyRefit: Whether refit both P and lams or only lams.
+  ## refitFully: Whether refit both P and lams or only lams.
   ## verbose: Whether to print information on optimization processes.
-  ## tol: Tolerance hyper-parameter for stopping criterion.
-  ## tolPower: Tolerance hyper-parameter for stopping criterion 
-  ## in power iteration.
-  result = GreedyCoordinateDescent(
+  ##          0: no printing.
+  ##          1: prints the value of objective function at outer loop.
+  ##          2: prints the value of objective function at innter loop.
+  ##          3: prints the value of objective function at ADMM loop
+  ##             (for refitFully=True).
+  ## tol: Tolerance hyperparameter for stopping criterion.
+  ##      If the decreasing of the objective value is smaller than tol,
+  ##      then this solver stops.
+  ## tolPower: Tolerance hyperparameter for stopping criterion 
+  ##           of power iteration.
+  ## sigma: Parameter for line search in fully refitting.
+  ## maxIterADMM: Maximum number of iteration of ADMM in fully refitting.
+  ## tolADMM: Tolerance hyperparameter of stopping criterion of ADMM 
+  ##          in fully refitting.
+  ## maxIterLineSearch: Maximum number of interation of line seaerch 
+  ##                    in fully refitting.
+  result = GreedyCD(
     maxIter: maxIter, maxIterInner: maxIterInner, nRefitting: nRefitting,
-    fullyRefit: fullyRefit, tol: tol, verbose: verbose,
-    maxIterPower: maxIterPower, tolPower: tolPower)
+    refitFully: refitFully, tol: tol, verbose: verbose,
+    maxIterPower: maxIterPower, tolPower: tolPower, sigma: sigma,
+    maxIterADMM: maxIterADMM, tolADMM: tolADMM,
+    maxIterLineSearch: maxIterLineSearch)
 
 
-proc powerIteration(X: CSCDataset, dL: Vector, p, cache: var Vector,
-                    maxIter=20, tol=1e-4, ignoreDiag: bool) =
-  var pj = 0.0
-  var norm = 0.0
-  let nSamples = X.nSamples
-  let nFeatures = X.nFeatures
-  var ev, evOld: float64
-  # init p
-  for j in 0..<nFeatures:
-    p[j] = 2*rand(1.0) - 1.0
-  p /= norm(p, 2)
-  # start power iteration
-  for it in 0..<maxIter:
-    # compute X^\top R X p
-    # compute Xp
-    linear(X, p, cache)
-    # compute R X p
-    for i in 0..<nSamples:
-      cache[i] *= dL[i]
-    ev = 0.0
-    # compute X^\top R X p
-    # compute eigen value
-    for j in 0..<nFeatures:
-      pj = 0.0
-      for (i, val) in X.getCol(j):
-        pj += val * cache[i]
-        if ignoreDiag:
-          pj -= dL[i]*p[j]*val^2
-      ev += pj*p[j]
-      p[j] = pj
-    p /= norm(p, 2)
-    if it > 0 and abs(ev-evOld) < tol:
-      break
-    evOld = ev
+proc objectiveADMM[L](y, yPred: Vector, A, B, M: Matrix, rho: float, 
+                      loss: L): float =
+  for i in 0..<len(y):
+    result += loss.loss(y[i], yPred[i])
+  result += 0.5 * rho * norm(A-B+M, 2)^2
 
 
 proc fitLams(lams: var Vector, s: int, beta: float64,
@@ -86,7 +77,7 @@ proc fitLams(lams: var Vector, s: int, beta: float64,
     norm += K[s, i]^2
   invStepSize = mu * norm
   lams[s] -= update / invStepSize
-  # soft thresholding
+  # Soft-thresholding
   if (lams[s] - beta / invStepSize) > 0:
     lams[s] -= beta/invStepSize
   elif (lams[s] + beta / invStepSize) < 0:
@@ -95,9 +86,8 @@ proc fitLams(lams: var Vector, s: int, beta: float64,
     lams[s] = 0
 
 
-proc refitDiag(y: seq[float64], yPred: var seq[float64], lams: var Vector,
-               beta: float64, loss: LossFunction, K: Matrix,
-               dL: var Vector): int =
+proc refitDiag[L](y: seq[float64], yPred: var seq[float64], beta: float64, 
+                  loss: L, K: Matrix, lams, dL: var Vector): int =
   let nSamples = len(y)
   result = 0
   for s in 0..<len(lams):
@@ -106,98 +96,308 @@ proc refitDiag(y: seq[float64], yPred: var seq[float64], lams: var Vector,
         dL[i] = loss.dloss(y[i], yPred[i])
       var lamOld = lams[s]
       fitLams(lams, s, beta, K, dL, loss.mu)
-      for i in 0..<nSamples:
-        yPred[i] -= (lamOld-lams[s]) * K[s, i]
+      yPred -= (lamOld-lams[s]) * K[s]
 
       if lams[s] != 0: result += 1
 
 
-proc fitZ(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
-          yPred: var seq[float64], P: var Matrix, lams: var Vector,
-          beta: float64, loss: LossFunction, A: var Matrix, K: var Matrix,
-          p, dL, cache: var  Vector, maxComponents, verbose: int,
-          ignoreDiag: bool): float64 =
+proc runADMM[L](self: GreedyCD, y: Vector, yPred: var Vector, X: CSCDataset,
+                beta: float64, loss: L, P, K: Matrix, lams, dL: var Vector,
+                ignoreDiag: bool, A, B, M: var Matrix, 
+                nSamples, nFeatures, nComponents: int): void = 
+  var vecdA = zeros([nComponents^2])
+  var vecD = zeros([nComponents^2])
+  var D = zeros([nComponents, nComponents])
+  var AP = matmul(A, P)
+  var DP = zeros([nComponents, nFeatures])
+  var PXT = zeros([nComponents, nSamples])
+  var DPXT = zeros([nComponents, nSamples])
+  var diagPTDP = zeros([nFeatures])
+  var pi = zeros([nSamples])
+  var ev = zeros([nComponents])
+  var yPredQuad = zeros([nSamples])
+  var yPredDiff = zeros([nSamples])
+  var delta: Vector
+  var rho = 1.0
+  let PT = P.T
+
+  if ignoreDiag:
+    delta = zeros([nFeatures])
+
+  # compute cache PXT
+  PXT[0..^1, 0..^1] = 0.0
+  for s in 0..<nComponents:
+    linear(X, P[s], PXT[s]) # O(nComponents * nnz(X))
+
+  # Linear operator for newton-cg
+  proc linearOp(p: Vector, result: var Vector): void =
+    # substitute D
+    for s1 in 0..<nComponents:
+      for s2 in 0..<nComponents:
+        D[s1, s2] = p[s1+s2*nComponents]
+    # compute pi
+    matmul(D, P, DP) # O(nComponents^2 * nFeatures)
+    for s in 0..<nComponents:
+      linear(X, DP[s], DPXT[s]) # O(nComponents * nnz(X))
+    pi = sum(DPXT*PXT, axis=0) # O(nComponents * nSamples)
+    if ignoreDiag:
+      diagPTDP = sum(P*DP, axis=0) # O(nComponents * nFeatures)
+      for j in 0..<nFeatures: # O(nnz(X))
+        for (i, val) in X.getCol(j):
+          pi[i] -= val * val * diagPTDP[j]
+      pi *= 0.5
+
+    # result = vec(matmul(PXT*pi, PXT.T)) # O(nComponents^2 * nSamples), slow
+    # Fast (?): O(nComponents * nnz(X) + nComponents^2 nFeatures)
+    result = vec(matmul(matmul(PXT*pi, X), PT)) 
+    if ignoreDiag:
+      delta[0..^1] = 0.0 # = vmmul(pi, X*X)
+      for j in 0..<nFeatures: # O(nnz(X))
+        for (i, val) in X.getCol(j):
+          delta[j] += pi[i] * val * val
+      result -= vec(matmul(P*delta, PT)) # O(nComponents^2 * nFeatures)
+    result += rho * p
+  
+  # preconditioner for conjugate gradient
+  var diagHesseApprox = zeros([nComponents^2])
+  for s1 in 0..<nComponents: # O(nSamples * nComponents^2)
+    for s2 in 0..<nComponents:
+      for i in 0..<nSamples:
+        diagHesseApprox[s1*nComponents+s2] = (PXT[s1, i]^2) * (PXT[s2, i]^2)
+  diagHesseApprox *= loss.mu
+  diagHesseApprox += 1e-5
+  proc preconditioner(p: var Vector): void =
+    p /= (diagHesseApprox + rho)
+
+
+  # Perform ADMM
+  for itADMM in 0..<self.maxIterADMM:
+    # optimize A
+    # compute gradient wrt A, vecdA
+    for i in 0..<nSamples: dL[i] = loss.dloss(y[i], yPred[i])
+    vecD[0..^1] = 0.0
+    # vecdA = vec(matmul(PXT*dL, PXT.T)+rho*(A-B+M)) # O(n*k^2), slow
+    # Fast (?): O(nComponents * nnz(X) + nComponents^2 nFeatures)
+    vecdA = vec(matmul(matmul(PXT*dL, X), PT) + rho*(A-B+M)) 
+    if ignoreDiag:
+      delta[0..^1] = 0.0 # vmmul(dL, X*X)
+      for j in 0..<nFeatures: # O(nnz(X))
+        for (i, val) in X.getCol(j):
+          delta[j] += dL[i] * val * val
+      vecdA -= vec(matmul(P*delta, PT)) # O(nComponents^2 * nFeatures)
+      vecdA *= 0.5
+    
+    # compute update direction D and recompute DP
+    let maggrad = norm(vecdA, 1)
+    let tolCG = 1e-3 * maggrad
+    # cg(linearOp, vecdA, vecD, maxIter=200, tol=tolCG)
+    cg(linearOp, vecdA, vecD, maxIter=200, tol=tolCG, 
+       preconditioner=preconditioner)
+    for s1 in 0..<nComponents:
+      for s2 in 0..<nComponents:
+        D[s1, s2] = vecD[s1+s2*nComponents]
+    matmul(D, P, DP)
+   
+    # compute quadratic term wrt D
+    DPXT[0..^1, 0..^1] = 0.0
+    for s in 0..<nComponents:
+      linear(X, DP[s], DPXT[s])
+    yPredDiff = sum(DPXT * PXT, axis=0)
+    if ignoreDiag:
+      diagPTDP = sum(P*DP, axis=0)
+      for j in 0..<nFeatures:
+        for (i, val) in X.getCol(j):
+          yPredDiff[i] -= val * val * diagPTDP[j]
+      yPredDiff *= 0.5
+    
+    # perform line search
+    var eta = 1.0
+    let condition = - self.sigma * dot(vecdA, vecD)
+    let objOld = objectiveADMM(y, yPred, A, B, M, rho, loss)
+    yPred -= eta * yPredDiff
+    A -= eta * D
+    for itSearch in 0..<self.maxIterLineSearch:
+      let objNew = objectiveADMM(y, yPred, A, B, M, rho, loss)
+      if (objNew - objOld) < eta * condition: break
+      eta *= 0.5
+      # yPred += 2 * eta * yPredDiff - eta * yPredDiff
+      yPred += eta * yPredDiff
+      A += eta * D
+    # line search done, update A, AP, and yPred
+    yPredQuad += eta * yPredDiff
+    matmul(A, P, AP)
+
+    # optimize B
+    D = B # D = old B
+    B = A + M
+    dsyev(B, ev, columnWise=true)
+    for s in 0..<nComponents: # soft-thresholding wrt eigenvalues
+      ev[s] = float64(sgn(ev[s]))*max(0.0, abs(ev[s]) - beta / rho)
+    B = matmul(B*ev, B.T)
+
+    # optimize M
+    M += rho * A
+    M -= rho * B
+
+    # stopping criterion
+    let primalResidual = norm(A-B, 2)
+    let dualResidual = rho * norm(B-D, 2)
+    if primalResidual < self.tolADMM and dualResidual < self.tolADMM: break
+    
+    # adapt rho
+    if primalResidual > 10.0 * dualResidual: rho *= 2.0
+    elif dualResidual > 10.0 * primalResidual: rho /= 2.0
+    if self.verbose > 2:
+      stdout.write(fmt"    Iteration (ADMM): {itADMM}")
+      stdout.write(fmt"  Primal Residual: {primalResidual:1.4e}")
+      stdout.write(fmt"  Dual Residual: {dualResidual:1.4e}")
+      stdout.write("\n")
+      stdout.flushFile()
+
+  yPred += yPredQuad
+
+
+proc refitFully[L](self: GreedyCD, y: Vector, yPred: var Vector, X: CSCDataset,
+                   beta: float64, loss: L, P, K, cacheK: var Matrix, 
+                   lams, dL: var Vector, ignoreDiag: bool): int = 
+  var nComponents = 0
+  # Squeeze P and lams
+  let nSamples = len(y)
+  let nFeatures = X.nFeatures
+  for s in 0..<len(lams):
+    if lams[s] != 0:
+      lams[nComponents] = lams[s]
+      P[nComponents] = P[s]
+      inc(nComponents)
+      yPred -= lams[s] * K[s]
+  # unused variables set to be zeros
+  for s in nComponents..<len(lams):
+    lams[s] = 0.0
+    P[s, 0..^1] = 0.0
+    K[s, 0..^1] = 0.0
+  
+  var A = eye(nComponents)
+  var B = eye(nComponents)
+  var M = zeros([nComponents, nComponents])
+
+  orthogonalize(P, nComponents)
+  # recompute Kernels
+  for s in 0..<nComponents:
+    if ignoreDiag: anova(X, P, cacheK, 2, s, 0)
+    else: poly(X, P, cacheK, 2, s, 0)
+    K[s] = cacheK[0..^1, 2]
+    yPred += K[s]
+  
+  # optimize A, B, and M
+  runADMM(self, y, yPred, X, beta, loss, P[0..<nComponents], K, lams, dL,
+          ignoreDiag, A, B, M, nSamples, nFeatures, nComponents)
+  # finalize A
+  var ev = zeros([nComponents])
+  dsyev(A, ev, columnWise=false)
+  result = int(norm(ev, 0))
+  P[0..<nComponents] = matmul(A, P[0..<nComponents])
+  lams[0..<nComponents] = ev
+
+  # synchronize predictions
+  for s in 0..<nComponents:
+    yPred -= K[s]
+    K[s, 0..^1] = 0.0
+  for s in 0..<result:
+    if ignoreDiag: anova(X, P, cacheK, 2, s, 0)
+    else: poly(X, P, cacheK, 2, s, 0)
+    K[s] = cacheK[0..^1, 2]
+    yPred += K[s] * lams[s]
+
+
+proc fitZ[L](self: GreedyCD, X: CSCDataset, y: seq[float64],
+             yPred: var seq[float64], P: var Matrix, lams: var Vector,
+             beta: float64, loss: L, cacheK: var Matrix, K: var Matrix,
+             maxComponents, verbose: int, ignoreDiag: bool): float64 =
   var nComponents = 0
   let nSamples = X.nSamples
+  let nFeatures = X.nFeatures
   var lossOld = 0.0
   var addBase = false
-  for s in 0..<len(lams):
-    if lams[s] != 0.0: nComponents += 1
-
+  var dL = zeros([nSamples])
+  var Xp = zeros([nSamples])
+  var cache = zeros([nSamples])
+  nComponents = int(norm(lams, 0))
   for i in 0..<nSamples:
     lossOld += loss.loss(y[i], yPred[i])
-  for s in 0..<nComponents:
-    lossOld += beta * abs(lams[s])
+  lossOld += beta * norm(lams, 1)
   lossOld /= float(nSamples)
+  
+  proc linearOpPower(p: Vector, result: var Vector) =
+    mvmul(X, p, Xp)
+    Xp *= dL
+    vmmul(Xp, X, result)
+    if ignoreDiag:
+      for j in 0..<nFeatures:
+        for (i, val) in X.getCol(j):
+          result[j] -= val*val*dL[i]*p[j]
 
   for it in 0..<self.maxIterInner:
     result = 0.0
     addBase = false
-    # add new base (dominate eigenvector)
+    # Add a new vector to basis (dominate eigenvector)
     if nComponents < maxComponents:
-      # compute dL = residual for squared loss
+      # Compute dL = residual for squared loss
       for i in 0..<nSamples:
         dL[i] = loss.dloss(y[i], yPred[i])
-      powerIteration(X, dL, p, cache, self.maxIterPower, self.tolPower, 
-                     ignoreDiag)
-      # add new row or re-use existing row, which?
+      let (_, p) = powerMethod(linearOpPower, nFeatures, self.maxIterPower, 
+                               self.tolPower)
+      # Add a new row or re-use existing row, which?
       var sNew = len(lams)
       for s in 0..<len(lams):
-        if lams[s] == 0: # re-use existing row
+        if lams[s] == 0.0: # re-use existing row
           sNew = s
           break
-      # add new row
+      # Add a new row
       if sNew == len(lams):
         lams.add(0.0)
         P.addRow(p)
-      else: # substitute
-        for i in 0..<len(p):
-          P[sNew, i] = p[i]
-      if ignoreDiag: anova(X, P, A, 2, sNew, 0)
-      else: poly(X, P, A, 2, sNew, 0)
-
-      for i in 0..<nSamples:
-        cache[i] = A[i, 2]
-      if sNew == len(K): # add new row
+      else: # Re-use
+        P[sNew] = p
+      if ignoreDiag: anova(X, P, cacheK, 2, sNew, 0)
+      else: poly(X, P, cacheK, 2, sNew, 0)
+      cache = cacheK[0..^1, 2]
+      if sNew == len(K): # Add new row
         K.addRow(cache)
-      else: # re-use exiting row
-        for i in 0..<nSamples:
-          K[sNew, i] = cache[i]
-      # fit lams[sNew]
+      else: # Re-use
+        K[sNew] = cache
+      # Fit lams[sNew]
       fitLams(lams, sNew, beta, K, dL, loss.mu)
       if lams[sNew] != 0.0:
-        for i in 0..<nSamples:
-          yPred[i] += lams[sNew] * K[sNew, i]
+        yPred += lams[sNew] * K[sNew]
         nComponents += 1
         addBase = true
     
-    # refitting
+    # Refitting
     if (it+1) mod self.nRefitting == 0:
       # diagonal refitting
-      if not self.fullyRefit:
-        nComponents = refitDiag(y, yPred, lams, beta, loss, K, dL)
-      else:
-        raise newException(ValueError, "Not implemented, ToDo.")
-    
-    if addBase or (it+1) mod self.nRefitting == 0:
+      if not self.refitFully:
+        nComponents = refitDiag(y, yPred, beta, loss, K, lams, dL)
+      elif nComponents != 0:
+        nComponents = refitFully(self, y, yPred, X, beta, loss, P, K,
+                                 cacheK, lams, dL, ignoreDiag)
+    # if basis is changed or refitted
+    if addBase or (it+1) mod self.nRefitting == 0 or it == self.maxIterInner-1:
       # compute objective for stopping criterion
-      for s in 0..<len(lams):
-        result += abs(lams[s])
+      result += norm(lams, 1)
       result *= beta / float(nSamples)
       for i in 0..<nSamples:
         result += loss.loss(y[i], yPred[i])
       result /= float(nSamples)
       
       if verbose > 1:
-        stdout.write(
-          fmt"   Iteration: {align($(it+1), len($self.maxIterInner))}"
-        )
+        let iterAligned =  align($(it+1), len($self.maxIterInner))
+        stdout.write(fmt"   Iteration: {iterAligned}")
         stdout.write(fmt"   Objective: {result:1.4e}")
         stdout.write(fmt"   Decreasing: {lossOld - result:1.4e}")
         stdout.write("\n")
         stdout.flushFile()
 
-      # stopping criterion
+      # Stopping criterion
       if abs(result - lossOld) < self.tol:
         if verbose > 1:
           echo("   Converged at iteration ", it+1, ".")
@@ -205,57 +405,48 @@ proc fitZ(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
       lossOld = result
   
 
-proc fit*(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
-          cfm: var ConvexFactorizationMachine) =
+proc fit*[L](self: GreedyCD, X: CSCDataset, y: seq[float64],
+             cfm: var ConvexFactorizationMachine[L]) =
   ## Fits the factorization machine on X and y by coordinate descent.
   cfm.init(X)
   let y = checkTarget(cfm, y)
   let
     nSamples = X.nSamples
-    nFeatures = X.nFeatures
     maxComponents = cfm.maxComponents
     alpha0 = cfm.alpha0 * float(nSamples)
     alpha = cfm.alpha * float(nSamples)
     beta = cfm.beta * float(nSamples)
     fitLinear = cfm.fitLinear
     fitIntercept = cfm.fitIntercept
-    loss = newLossFunction(cfm.loss)
 
   # caches
   var
     yPred = newSeqWith(nSamples, 0.0)
-    A: Matrix = zeros([nSamples, 3])
+    cacheK: Matrix = zeros([nSamples, 3])
     K: Matrix = zeros([len(cfm.lams), nSamples])
-    p: Vector = zeros([nFeatures])
-    dL: Vector = zeros([nSamples])
-    cache: Vector = zeros([nSamples])
-    colNormSq: Vector = zeros([nFeatures])
+    colNormSq: Vector
     isConverged = false
     lossOld = 0.0
     lossNew = 0.0
   
   # init caches
-  for i in 0..<nSamples:
-    A[i, 0] = 1.0
+  cacheK[0..^1, 0] = 1.0
   if fitLinear:
-   for j in 0..<nFeatures:
-     for (_, val) in X.getCol(j):
-       colNormSq[j] += val^2
+    colNormSq = norm(X, p=2, axis=0)
+    colNormSq *= colNormSq
 
   # compute prediction
   linear(X, cfm.w, yPred)
-  for i in 0..<nSamples:
-    yPred[i] += cfm.intercept
+  yPred += cfm.intercept
   for s in 0..<len(cfm.lams):
-    if cfm.ignoreDiag: anova(X, cfm.P, A, 2, s, 0)
-    else: poly(X, cfm.P, A, 2, s, 0)
-    for i in 0..<nSamples:
-      yPred[i] += cfm.lams[s] * A[i, 2]
-      K[s, i] = A[i, 2]
+    if cfm.ignoreDiag: anova(X, cfm.P, cacheK, 2, s, 0)
+    else: poly(X, cfm.P, cacheK, 2, s, 0)
+    K[s] = cacheK[0..^1, 2]
+    yPred += cfm.lams[s] * K[s]
   
   # compute loss
   for i in 0..<nSamples:
-    lossOld += loss.loss(y[i], yPred[i])
+    lossOld += cfm.loss.loss(y[i], yPred[i])
   if fitLinear:
     lossOld += alpha * norm(cfm.w, 2)^2
   if fitIntercept:
@@ -269,17 +460,18 @@ proc fit*(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
       echo(fmt"Outer Iteration {it+1}")
     
     if fitIntercept:
-      discard fitInterceptCD(cfm.intercept, y, yPred, nSamples, alpha0, loss)
+      discard fitInterceptCD(cfm.intercept, y, yPred, nSamples, alpha0, 
+                             cfm.loss)
       lossNew += alpha0 * cfm.intercept^2
     
     if fitLinear:
-      discard fitLinearCD(cfm.w, X, y, yPred, colNormSq, alpha, loss)
-      lossNew += alpha0 * norm(cfm.w, 2)^2
+      discard fitLinearCD(cfm.w, X, y, yPred, colNormSq, alpha, cfm.loss)
+      lossNew += alpha * norm(cfm.w, 2)^2
 
     lossNew /= float(nSamples)
 
-    lossNew += fitZ(self, X, y, yPred, cfm.P, cfm.lams, beta, loss, A, K, p, dL,
-                    cache, maxComponents, self.verbose, cfm.ignoreDiag)
+    lossNew += fitZ(self, X, y, yPred, cfm.P, cfm.lams, beta, cfm.loss, cacheK,
+                    K, maxComponents, self.verbose, cfm.ignoreDiag)
     
     if self.verbose > 0:
       stdout.write(fmt"   Whole Objective: {lossNew:1.4e}")

--- a/src/nimfm/optimizers/greedy_coordinate_descent.nim
+++ b/src/nimfm/optimizers/greedy_coordinate_descent.nim
@@ -1,0 +1,295 @@
+import ../loss, ../dataset, ../tensor, ../kernels
+import ../convex_factorization_machine
+from ../fm_base import checkTarget, checkInitialized
+import fit_linear, optimizer_base
+import sequtils, math, random, strformat, strutils
+
+type
+  GreedyCoordinateDescent* = ref object of BaseCSCOptimizer
+    ## Greedy coordinate descent solver for convex factorization machines.
+    ## In this solver, the regularization for interaction is not 
+    ## squared Frobenius norm for P but the trace norm for interaction weight
+    ## matrix.
+    maxIterInner: int
+    maxIterPower: int
+    nRefitting: int
+    fullyRefit: bool
+    tolPower: float64
+
+
+proc newGreedyCoordinateDescent*(
+  maxIter = 100, maxIterInner=100, nRefitting=10, fullyRefit=false,
+  verbose = 2, tol = 1e-7, maxIterPower = 100, tolPower = 1e-6):
+     GreedyCoordinateDescent =
+  ## Creates new GreedyCoordinateDescent for ConvexFactorizationMachine.
+  ## maxIter: Maximum number of iteration for alternative optimization.
+  ## maxIterInner: Maximum number of iteration for optimizing Z (P and lambda).
+  ## maxIterPower: Maximum number of iteration for power iteration.
+  ## nRefitting: Frequency of the refitting lams and P in inner loop.
+  ##             If nRefitting > maxIterInner, lams and P are not reffitted.
+  ## fullyRefit: Whether refit both P and lams or only lams.
+  ## verbose: Whether to print information on optimization processes.
+  ## tol: Tolerance hyper-parameter for stopping criterion.
+  ## tolPower: Tolerance hyper-parameter for stopping criterion 
+  ## in power iteration.
+  result = GreedyCoordinateDescent(
+    maxIter: maxIter, maxIterInner: maxIterInner, nRefitting: nRefitting,
+    fullyRefit: fullyRefit, tol: tol, verbose: verbose,
+    maxIterPower: maxIterPower, tolPower: tolPower)
+
+
+proc powerIteration(X: CSCDataset, dL: Vector, p, cache: var Vector,
+                    maxIter=20, tol=1e-4, ignoreDiag: bool) =
+  var pj = 0.0
+  var norm = 0.0
+  let nSamples = X.nSamples
+  let nFeatures = X.nFeatures
+  var ev, evOld: float64
+  # init p
+  for j in 0..<nFeatures:
+    p[j] = 2*rand(1.0) - 1.0
+  p /= norm(p, 2)
+  # start power iteration
+  for it in 0..<maxIter:
+    # compute X^\top R X p
+    # compute Xp
+    linear(X, p, cache)
+    # compute R X p
+    for i in 0..<nSamples:
+      cache[i] *= dL[i]
+    ev = 0.0
+    # compute X^\top R X p
+    # compute eigen value
+    for j in 0..<nFeatures:
+      pj = 0.0
+      for (i, val) in X.getCol(j):
+        pj += val * cache[i]
+        if ignoreDiag:
+          pj -= dL[i]*p[j]*val^2
+      if ignoreDiag:
+        pj *= 0.5
+      ev += pj*p[j]
+      p[j] = pj
+    p /= norm(p, 2)
+    if it > 0 and abs(ev-evOld) < tol:
+      break
+    evOld = ev
+
+
+proc fitLams(lams: var Vector, s: int, beta: float64,
+             K: Matrix, dL: Vector, mu: float64) {.inline.} =
+  let nSamples = K.shape[1]
+  var
+    update = 0.0
+    invStepSize = 0.0
+    norm = 0.0
+  for i in 0..<nSamples:
+    update += dL[i] * K[s, i]
+    norm += K[s, i]^2
+  invStepSize = mu * norm
+  lams[s] -= update / invStepSize
+  # soft thresholding
+  if (lams[s] - beta / invStepSize) > 0:
+    lams[s] -= beta/invStepSize
+  elif (lams[s] + beta / invStepSize) < 0:
+    lams[s] += beta/invStepSize
+  else:
+    lams[s] = 0
+
+
+proc refitDiag(y: seq[float64], yPred: var seq[float64], lams: var Vector,
+               beta: float64, loss: LossFunction, K: Matrix,
+               dL: var Vector): int =
+  let nSamples = len(y)
+  result = 0
+  for s in 0..<len(lams):
+    if lams[s] != 0.0:
+      for i in 0..<nSamples:
+        dL[i] = loss.dloss(y[i], yPred[i])
+      var lamOld = lams[s]
+      fitLams(lams, s, beta, K, dL, loss.mu)
+      for i in 0..<nSamples:
+        yPred[i] -= (lamOld-lams[s]) * K[s, i]
+
+      if lams[s] != 0: result += 1
+
+
+proc fitZ(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
+          yPred: var seq[float64], P: var Matrix, lams: var Vector,
+          beta: float64, loss: LossFunction, A: var Matrix, K: var Matrix,
+          p, dL, cache: var  Vector, maxComponents, verbose: int,
+          ignoreDiag: bool): float64 =
+  var nComponents = 0
+  let nSamples = X.nSamples
+  var lossOld = 0.0
+  var addBase = false
+  for s in 0..<len(lams):
+    if lams[s] != 0.0: nComponents += 1
+
+  for i in 0..<nSamples:
+    lossOld += loss.loss(y[i], yPred[i])
+  for s in 0..<nComponents:
+    lossOld += beta * abs(lams[s])
+  lossOld /= float(nSamples)
+
+  for it in 0..<self.maxIterInner:
+    result = 0.0
+    addBase = false
+    # add new base (dominate eigenvector)
+    if nComponents < maxComponents:
+      # compute dL = residual for squared loss
+      for i in 0..<nSamples:
+        dL[i] = loss.dloss(y[i], yPred[i])
+      powerIteration(X, dL, p, cache, self.maxIterPower, self.tolPower, 
+                     ignoreDiag)
+      # add new row or re-use existing row, which?
+      var sNew = len(lams)
+      for s in 0..<len(lams):
+        if lams[s] == 0: # re-use existing row
+          sNew = s
+          break
+      # add new row
+      if sNew == len(lams):
+        lams.add(0)
+        P.addRow(p)
+      if ignoreDiag: anova(X, P, A, 2, sNew, 0)
+      else: poly(X, P, A, 2, sNew, 0)
+
+      for i in 0..<nSamples:
+        cache[i] = A[i, 2]
+      if sNew == len(K): # add new row
+        K.addRow(cache)
+      else: # re-use exiting row
+        for i in 0..<nSamples:
+          K[sNew, i] = cache[i]
+      # fit lams[sNew]
+      fitLams(lams, sNew, beta, K, dL, loss.mu)
+      for i in 0..<nSamples:
+        yPred[i] += lams[sNew] * K[sNew, i]
+      if lams[sNew] != 0.0:
+        nComponents += 1
+        addBase = true
+    
+    # refitting
+    if (it+1) mod self.nRefitting == 0:
+      # diagonal refitting
+      if not self.fullyRefit:
+        nComponents = refitDiag(y, yPred, lams, beta, loss, K, dL)
+      else:
+        raise newException(ValueError, "Not implemented, ToDo.")
+    
+    if addBase or (it+1) mod self.nRefitting == 0:
+      # compute objective for stopping criterion
+      result = 0.0
+      for s in 0..<len(lams):
+        result += abs(lams[s])
+      result *= beta / float(nSamples)
+      for i in 0..<nSamples:
+        result += loss.loss(y[i], yPred[i])
+      result /= float(nSamples)
+      
+      if verbose > 1:
+        stdout.write(
+          fmt"   Iteration: {align($(it+1), len($self.maxIterInner))}"
+        )
+        stdout.write(fmt"   Objective: {result:1.4e}")
+        stdout.write(fmt"   Dicreasing: {lossOld - result:1.4e}")
+        stdout.write("\n")
+        stdout.flushFile()
+
+      # stopping criterion
+      if abs(result - lossOld) < self.tol:
+        if verbose > 1:
+          echo("   Converged at iteration ", it+1, ".")
+        break
+      lossOld = result
+  
+
+proc fit*(self: GreedyCoordinateDescent, X: CSCDataset, y: seq[float64],
+          cfm: var ConvexFactorizationMachine) =
+  ## Fits the factorization machine on X and y by coordinate descent.
+  cfm.init(X)
+  let y = checkTarget(cfm, y)
+  let
+    nSamples = X.nSamples
+    nFeatures = X.nFeatures
+    maxComponents = cfm.maxComponents
+    alpha0 = cfm.alpha0 * float(nSamples)
+    alpha = cfm.alpha * float(nSamples)
+    beta = cfm.beta * float(nSamples)
+    fitLinear = cfm.fitLinear
+    fitIntercept = cfm.fitIntercept
+    loss = newLossFunction(cfm.loss)
+
+  # caches
+  var
+    yPred = newSeqWith(nSamples, 0.0)
+    A: Matrix = zeros([nSamples, 3])
+    K: Matrix = zeros([len(cfm.lams), nSamples])
+    p: Vector = zeros([nFeatures])
+    dL: Vector = zeros([nSamples])
+    cache: Vector = zeros([nSamples])
+    colNormSq: Vector = zeros([nFeatures])
+    isConverged = false
+    lossOld = 0.0
+    lossNew = 0.0
+  
+  # init caches
+  for i in 0..<nSamples:
+    A[i, 0] = 1.0
+  if fitLinear:
+   for j in 0..<nFeatures:
+     for (_, val) in X.getCol(j):
+       colNormSq[j] += val^2
+
+  # compute prediction
+  linear(X, cfm.w, yPred)
+  for i in 0..<nSamples:
+    yPred[i] += cfm.intercept
+  for s in 0..<len(cfm.lams):
+    if cfm.ignoreDiag: anova(X, cfm.P, A, 2, s, 0)
+    else: poly(X, cfm.P, A, 2, s, 0)
+    for i in 0..<nSamples:
+      yPred[i] += cfm.lams[s] * A[i, 2]
+      K[s, i] = A[i, 2]
+  
+  # compute loss
+  for i in 0..<nSamples:
+    lossOld += loss.loss(y[i], yPred[i])
+  if fitLinear:
+    lossOld += alpha * norm(cfm.w, 2)^2
+  if fitIntercept:
+    lossOld += alpha0 * cfm.intercept^2
+  lossOld /= float(nSamples)
+
+  # start iteration
+  for it in 0..<self.maxIter:
+    lossNew = 0.0
+    if self.verbose > 0:
+      echo(fmt"Outer Iteration {it+1}")
+    
+    if fitIntercept:
+      discard fitInterceptCD(cfm.intercept, y, yPred, nSamples, alpha0, loss)
+      lossNew += alpha0 * cfm.intercept^2
+    
+    if fitLinear:
+      discard fitLinearCD(cfm.w, X, y, yPred, colNormSq, alpha, loss)
+      lossNew += alpha0 * norm(cfm.w, 2)^2
+
+    lossNew /= float(nSamples)
+
+    lossNew += fitZ(self, X, y, yPred, cfm.P, cfm.lams, beta, loss, A, K, p, dL,
+                    cache, maxComponents, self.verbose, cfm.ignoreDiag)
+    
+    if self.verbose > 0:
+      stdout.write(fmt"   Whole Objective: {lossNew:1.4e}")
+      stdout.write("\n")
+    if abs(lossNew - lossOld) < self.tol:
+      if self.verbose > 0:
+        echo("Converged at iteration ", it+1, ".")
+      isConverged = true
+      break
+    lossOld = lossNew
+
+  if not isConverged and self.verbose > 0:
+    echo("Objective did not converge. Increase maxIter.")

--- a/src/nimfm/optimizers/hazan.nim
+++ b/src/nimfm/optimizers/hazan.nim
@@ -1,0 +1,213 @@
+import ../dataset, ../tensor, ../kernels, ../extmath, ../utils, ../loss
+import ../convex_factorization_machine
+from ../fm_base import checkTarget, checkInitialized
+import optimizer_base
+import math, strformat, strutils
+
+type
+  Hazan* = ref object of BaseCSCOptimizer
+    ## Hazan's algorithm for convex factorization machines with SquaredLoss.
+    ## This solver solves not regularized problem but constrained problem
+    ## such that trace norm of the interaction weight matrix = eta.
+    ## Regularization parameters alpha0, alpha, and beta
+    ## in ConvexFactorizationMachine are ignored.
+    maxIterPower: int
+    tolPower: float64
+    optimal: bool
+    nTol: int
+    it: int # for warm-start with optimal=false
+
+
+proc newHazan*(
+  maxIter = 100, verbose = 2, tol = 1e-7, nTol=10, maxIterPower = 1000,
+  tolPower = 1e-7, optimal = true): Hazan =
+  ## Creates new Hazan for ConvexFactorizationMachine.
+  ## maxIter: Maximum number of iteration for alternative optimization.
+  ## maxIterPower: Maximum number of iteration for power iteration.
+  ## verbose: Whether to print information on optimization processes.
+  ## tol: Tolerance hyperparameter for stopping criterion.
+  ##      If the decreasing of the objective value is smaller than tol
+  ##      with nTol times in a row, then this solver stops.
+  ## nTol: Tolerance hyperparameter for stopping criterion.
+  ##       If the decreasing of the objective value is smaller than tol
+  ##       with nTol times in a row, then this solver stops.
+  ## tolPower: Tolerance hyperparameter for stopping criterion 
+  ##           of power iteration.
+  ## optimal: Whether to use optimal step-size or not (2.0 / (t+2.0)).
+  ##          If optimal is true, this solver does not stop optimization
+  ##          even when nComponents > maxComponents and replaces 
+  ##          the old basis vector whose lam is minimum with the new one.
+  result = Hazan(
+    maxIter: maxIter, tol: tol, verbose: verbose, nTol: nTol,
+    maxIterPower: maxIterPower, tolPower: tolPower, optimal: optimal)
+
+
+proc fit*(self: Hazan, X: CSCDataset, y: seq[float64],
+          cfm: var ConvexFactorizationMachine[Squared]) =
+  ## Fits the factorization machine on X and y by coordinate descent.
+  cfm.init(X)
+  let y = checkTarget(cfm, y)
+  let
+    nSamples = X.nSamples
+    nFeatures = X.nFeatures
+    fitLinear = cfm.fitLinear
+    fitIntercept = cfm.fitIntercept
+    ignoreDiag = cfm.ignoreDiag
+
+  # caches
+  var
+    yPredLinear: Vector = zeros([nSamples])
+    yPredQuad: Vector = zeros([nSamples])
+    residual: Vector = zeros([nSamples])
+    cacheK: Matrix = zeros([nSamples, 3])
+    K: Matrix = zeros([len(cfm.lams), nSaMples])
+    w: Vector
+    Xp = zeros([nSamples])
+    resZ: Vector
+    colNormSq: Vector
+    isConverged = false
+    lossOld = 0.0
+    lossNew = 0.0
+
+  if not cfm.warmStart:
+    self.it = 0
+
+  if fitLinear:
+    w = cfm.w[0..<nFeatures]
+    resZ = zeros([nFeatures])
+    colNormSq = norm(X, p=2, axis=0)
+    if fitIntercept: 
+      w.add(cfm.intercept)
+      colNormSq.add(1.0)
+      resZ.add(0.0)
+    colNormSq += 1e-5
+
+  # compute prediction
+  linear(X, cfm.w, yPredLinear)
+  yPredLinear += cfm.intercept
+  for s in 0..<len(cfm.lams):
+    if ignoreDiag: 
+      anova(X, cfm.P, cacheK, 2, s, 0)
+    else: 
+      poly(X, cfm.P, cacheK, 2, s, 0)
+    K[s] = cacheK[0..^1, 2]
+    yPredQuad += cfm.lams[s] * K[s]
+
+
+  # linear map for PowerMethod
+  proc linearOpPower(p: Vector, result: var Vector) =
+    mvmul(X, p, Xp)
+    Xp *= residual
+    vmmul(Xp, X, result)
+    if ignoreDiag:
+      for j in 0..<nFeatures:
+        for (i, val) in X.getCol(j):
+          result[j] -= val*val*residual[i]*p[j]
+
+  # linear map for CG
+  proc linearOpCG(w: Vector, result: var Vector) =
+    mvmul(X, w[0..<nFeatures], Xp)
+    if fitIntercept: Xp += w[^1]
+    vmmul(Xp, X, result)
+    if fitIntercept: result[^1] = sum(Xp)
+
+  # preconditioner for CG
+  proc preconditioner(w: var Vector) = w /= colNormSq
+
+  # start optimization
+  residual = y - yPredQuad - yPredLinear
+  lossOld = norm(residual, 2)^2 / float(nSamples)
+  var stepsize = 0.0
+  var nTol = 0
+  for it in 0..<self.maxIter:
+    if not self.optimal and len(cfm.lams) >= cfm.maxComponents:
+      break
+    # fit P
+    let (_, p) = powerMethod(linearOpPower, nFeatures, self.maxIterPower,
+                             tol=self.tolPower)
+    # Add or replace? 
+    var s = len(cfm.lams)
+    if s == cfm.maxComponents: # replace old p
+      s = argmin(cfm.lams) # replace old p whose lambda is minimum
+      yPredQuad -= cfm.lams[s] * K[s]
+      cfm.P[s] = p
+    else: # add new p
+      cfm.P.addRow(p)
+
+    if ignoreDiag: 
+      anova(X, cfm.P, cacheK, 2, s, 0)
+    else:
+      poly(X, cfm.P, cacheK, 2, s, 0)
+    
+    if s != len(cfm.lams): # replace old p
+      yPredQuad += cfm.lams[s] * K[s]
+      residual = y - yPredQuad - yPredLinear
+      K[s] = cacheK[0..^1, 2]
+    else:
+      K.addRow(cacheK[0..^1, 2]) # add new p
+    
+    # compute stepsize
+    if self.optimal:
+      let d = cfm.eta * K[s] - yPredQuad
+      stepsize = dot(d, residual) / norm(d, 2)^2
+      stepsize = min(max(1e-10, stepsize), 1.0)
+    else:
+      stepsize = 2.0 / (float(self.it)+2.0)
+    # update lams
+    if len(cfm.lams) != 0 and sum(cfm.lams) + cfm.eta * stepsize > cfm.eta:
+      yPredQuad *= cfm.eta * (1.0 - stepsize) / sum(cfm.lams)
+      cfm.lams *= cfm.eta * (1.0 - stepsize) / sum(cfm.lams)
+    if s == len(cfm.lams):
+      cfm.lams.add(cfm.eta*stepsize)
+    else:
+      cfm.lams[s] += cfm.eta*stepsize
+
+    # update predictions
+    yPredQuad += cfm.eta * stepsize * K[s]
+
+    # fit w
+    residual = y - yPredQuad
+    if fitLinear:
+      # optimize w by conjugate gradient
+      resZ[0..<nFeatures] = vmmul(residual, X)
+      if fitIntercept:
+        resZ[^1] = sum(residual)
+      let maggrad = norm(resZ, 1)
+      let tolCG = 1e-5 * maggrad
+      w *= colNormSq # since we use left and right preconditioning
+      cg(linearOpCG, resZ, w, maxIter=1000, preconditioner=preconditioner,
+         init=false, tol=tolCG)
+      # substitute and update prediction
+      cfm.w = w[0..<nFeatures]
+      mvmul(X, cfm.w, yPredLinear)
+      if fitIntercept:
+        cfm.intercept = w[^1]
+        yPredLinear += cfm.intercept
+    elif fitIntercept:
+      cfm.intercept = sum(residual) / float(nSamples)
+      yPredLinear[0..<nSamples] = cfm.intercept
+
+    # stopping criterion
+    residual = y - yPredQuad - yPredLinear
+    lossNew = norm(residual, 2)^2  / float(nSamples)
+    if self.verbose > 0:
+      let epochAligned = align($(self.it), len($self.maxIter))
+      stdout.write(fmt"Epoch: {epochAligned}")
+      stdout.write(fmt"   MSE: {lossNew:1.4e}")
+      stdout.write("\n")
+    
+    if lossOld - lossNew < self.tol:
+      inc(nTol)
+      if ntol >= self.nTol:
+        if self.verbose > 0:
+          echo("Converged at iteration ", self.it+1, ".")
+        isConverged = true
+        break
+    else:
+      nTol = 0
+  
+    lossOld = lossNew
+    inc(self.it)
+
+  if not isConverged and self.verbose > 0:
+    echo("Objective did not converge. Increase maxIter.")

--- a/src/nimfm/optimizers/optimizer_base.nim
+++ b/src/nimfm/optimizers/optimizer_base.nim
@@ -1,5 +1,3 @@
-import ../dataset, ../factorization_machine
-
 type
   BaseOptimizerObj = object of RootObj
     verbose*: int
@@ -11,11 +9,3 @@ type
   BaseCSCOptimizer* = ref object of BaseOptimizer
 
   BaseCSROptimizer* = ref object of BaseOptimizer
-
-
-proc fit*(self: BaseCSCOptimizer, X: CSCDataset, y: seq[float64],
-          fm: FactorizationMachine) = discard
-
-
-proc fit*(self: BaseCSROptimizer, X: CSRDataset, y: seq[float64],
-          fm: FactorizationMachine) = discard

--- a/src/nimfm/optimizers/optimizer_base.nim
+++ b/src/nimfm/optimizers/optimizer_base.nim
@@ -2,7 +2,7 @@ import ../dataset, ../factorization_machine
 
 type
   BaseOptimizerObj = object of RootObj
-    verbose*: bool
+    verbose*: int
     tol*: float64
     maxIter*: int
 

--- a/src/nimfm/optimizers/optimizers.nim
+++ b/src/nimfm/optimizers/optimizers.nim
@@ -1,0 +1,2 @@
+import coordinate_descent, sgd, greedy_coordinate_descent, hazan
+export coordinate_descent, sgd, greedy_coordinate_descent, hazan

--- a/src/nimfm/optimizers/sgd.nim
+++ b/src/nimfm/optimizers/sgd.nim
@@ -1,4 +1,4 @@
-import ../loss, ../dataset, ../tensor, ../factorization_machine, ../fm_base
+import ../dataset, ../tensor, ../factorization_machine, ../fm_base
 import fit_linear, optimizer_base
 import sequtils, math, random, strformat, strutils
 
@@ -28,8 +28,8 @@ proc newSGD*(eta0 = 0.01, scheduling = optimal, power = 1.0, maxIter = 100,
   ##  - pegasos: eta = 1.0 / (regul * it),
   ##  where regul is the regularization strength hyper-parameter.
   ## power: Hyper-parameter for step size scheduling.
-  ## maxIter: Maximum number of iteration. In one iteration. \
-  ## all parameters are updated once by using all samples.
+  ## maxIter: Maximum number of iteration. At each iteration,
+  ##          all parameters are updated nSamples time.
   ## verbose: Whether to print information on optimization processes.
   ## tol: Tolerance hyper-parameter for stopping criterion.
   ## shuffle: How to choose one instance: cyclic (false) or random permutation
@@ -39,7 +39,7 @@ proc newSGD*(eta0 = 0.01, scheduling = optimal, power = 1.0, maxIter = 100,
                shuffle: shuffle)
 
 
-proc getEta(self: SGD, reg: float64): float64 {.inline.} =
+proc getEta*[T](self: T, reg: float64): float64 {.inline.} =
   case self.scheduling
   of constant:
     result = self.eta0
@@ -54,7 +54,7 @@ proc getEta(self: SGD, reg: float64): float64 {.inline.} =
 proc computeAnova(P: Matrix, X: CSRDataset,
                   i, degree, nAugments: int, A: var Matrix,
                   dA: var Matrix, dAcache: var Vector,
-                  PScaling: float64, PScalings: seq[float64]): float64 =
+                  scaling_P: float64, scalings_P: seq[float64]): float64 =
   result = 0.0
   let
     nComponents = P.shape[1]
@@ -67,7 +67,7 @@ proc computeAnova(P: Matrix, X: CSRDataset,
   # compute anova kernel
   for (j, val) in X.getRow(i):
     for s in 0..<nComponents:
-      P[j, s] *= PScaling / PScalings[j]
+      P[j, s] *= scaling_P / scalings_P[j]
       for t in 0..<degree:
         A[s, degree-t] += A[s, degree-t-1] * P[j, s] * val
   # for augmented features
@@ -134,8 +134,8 @@ proc computeAnovaDeg2(P: Matrix, X: CSRDataset,
       dA[nFeatures, s] = A[s, 1] - P[nFeatures, s]
 
 
-proc fit*(self: SGD, X: CSRDataset, y: seq[float64],
-          fm: var FactorizationMachine) =
+proc fit*[L](self: SGD, X: CSRDataset, y: seq[float64],
+             fm: var FactorizationMachine[L]) =
   ## Fits the factorization machine on X and y by stochastic gradient descent.
   fm.init(X)
   let y = fm.checkTarget(y)
@@ -151,12 +151,11 @@ proc fit*(self: SGD, X: CSRDataset, y: seq[float64],
     fitLinear = fm.fitLinear
     fitIntercept = fm.fitIntercept
     nAugments = fm.nAugments
-    loss = newLossFunction(fm.loss)
   var
-    wScaling = 1.0
-    PScaling = 1.0
-    wScalings = newSeqWith(nFeatures, 1.0)
-    PScalings = newSeqWith(nFeatures, 1.0)
+    scaling_w = 1.0
+    scaling_P = 1.0
+    scalings_w = newSeqWith(nFeatures, 1.0)
+    scalings_P = newSeqWith(nFeatures, 1.0)
     A: Matrix = zeros([nComponents, degree+1])
     dAcache: Vector = zeros([degree])
     indices = toSeq(0..<nSamples)
@@ -182,19 +181,19 @@ proc fit*(self: SGD, X: CSRDataset, y: seq[float64],
       # synchronize (lazily update) and compute prediction
       var yPred = fm.intercept
       for (j, val) in X.getRow(i):
-        fm.w[j] *= wScaling / wScalings[j]
+        fm.w[j] *= scaling_w / scalings_w[j]
         yPred += fm.w[j] * val
       for order in 0..<nOrders:
         if (degree-order) > 2:
           yPred += computeAnova(P[order], X, i, degree-order, nAugments, 
-                                A, dA[order], dACache, PScaling, PScalings)
+                                A, dA[order], dACache, scaling_P, scalings_P)
         else:
           yPred += computeAnovaDeg2(P[order], X, i, nAugments, A,
-                                    dA[order], PScaling, PScalings)
-      runningLoss += loss.loss(y[i], yPred)
+                                    dA[order], scaling_P, scalings_P)
+      runningLoss += fm.loss.loss(y[i], yPred)
 
       # update parameters
-      let dL = loss.dloss(y[i], yPred)
+      let dL = fm.loss.dloss(y[i], yPred)
 
       if fitIntercept:
         let update = self.getEta(alpha0) * (dL + alpha0 * fm.intercept)
@@ -218,33 +217,34 @@ proc fit*(self: SGD, X: CSRDataset, y: seq[float64],
             P[order, j, s] -= update
       
       # update caches for scaling
-      wScaling *= (1-wEta*alpha)
-      PScaling *= (1-PEta*beta)
+      scaling_w *= (1-wEta*alpha)
+      scaling_P *= (1-PEta*beta)
       for (j, _) in X.getRow(i):
-        wScalings[j] = wScaling
-        PScalings[j] = PScaling
+        scalings_w[j] = scaling_w
+        scalings_P[j] = scaling_P
       
       # reset scalings in order to avoid numerical error
-      if fitLinear and wScaling < 1e-9:
+      if fitLinear and scaling_w < 1e-9:
         for j in 0..<nFeatures:
-          fm.w[j] *= wScaling / wScalings[j]
-          wScalings[j] = 1.0
-        wScaling = 1.0
-      if PScaling < 1e-9:
+          fm.w[j] *= scaling_w / scalings_w[j]
+          scalings_w[j] = 1.0
+        scaling_w = 1.0
+      if scaling_P < 1e-9:
         for order in 0..<nOrders:
           for j in 0..<nFeatures:
             for s in 0..<nComponents:
-              P[order, j, s] *= PScaling / PScalings[j]
+              P[order, j, s] *= scaling_P / scalings_P[j]
         for j in 0..<nFeatures:
-          PScalings[j] = 1.0
-        PScaling = 1.0
+          scalings_P[j] = 1.0
+        scaling_P = 1.0
       
       inc(self.it)
 
+    runningLoss /= float(nSamples)
     # one epoch done
     if self.verbose > 0:
-      runningLoss /= float(nSamples)
-      stdout.write(fmt"Epoch: {align($(epoch+1), len($self.maxIter))}")
+      let epochAligned = align($(epoch+1), len($self.maxIter))
+      stdout.write(fmt"Epoch: {epochAligned}")
       stdout.write(fmt"   Violation: {viol:1.4e}")
       stdout.write(fmt"   Loss: {runningLoss:1.4e}")
       stdout.write("\n")
@@ -253,18 +253,21 @@ proc fit*(self: SGD, X: CSRDataset, y: seq[float64],
       if self.verbose > 0: echo("Converged at epoch ", epoch, ".")
       isConverged = true
       break
-  
+    if runningLoss.classify == fcNan:
+      echo("Loss is NaN. Use smaller learning rate.")
+      break
+    
   if not isConverged and self.verbose > 0:
     echo("Objective did not converge. Increase maxIter.")
 
   # finalize
   if fitLinear:
     for j in 0..<nFeatures:
-      fm.w[j] *= wScaling / wScalings[j]
+      fm.w[j] *= scaling_w / scalings_w[j]
   for order in 0..<nOrders:
     for j in 0..<nFeatures:
       for s in 0..<nComponents:
-        P[order, j, s] *= PScaling / PScalings[j]
+        P[order, j, s] *= scaling_P / scalings_P[j]
         fm.P[order, s, j] = P[order, j, s]
     for j in nFeatures..<nFeatures+nAugments:
       for s in 0..<nComponents:

--- a/src/nimfm/tensor.nim
+++ b/src/nimfm/tensor.nim
@@ -1,43 +1,21 @@
 import sequtils, random, math
 
 type
-  Tensor* = ref object
-    data: seq[seq[seq[float64]]]
-    shape*: array[3, int]
+  Vector* = ref object
+    data: seq[float64]
+    shape*: array[1, int]
 
   Matrix* = ref object
     data: seq[seq[float64]]
     shape*: array[2, int]
 
-  Vector* = ref object
-    data: seq[float64]
-    shape*: array[1, int]
+  Tensor* = ref object
+    data: seq[Matrix]
+    shape*: array[3, int]
 
 
-proc len*[T: Tensor, Vector, Matrix](self: T): int =
+proc len*[T: Tensor|Matrix|Vector](self: T): int =
   result = self.shape[0]
-
-
-# for Tensor subsucription
-proc `[]`*(self: Tensor, i, j, k: int): var float64 {.inline.} =
-  result = self.data[i][j][k]
-proc `[]=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i][j][k] = val
-proc `[]+=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i][j][k] += val
-proc `[]-=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i][j][k] -= val
-
-
-# for Matrix subscription
-proc `[]`*(self: Matrix, i, j: int): var float64 {.inline.} =
-  result = self.data[i][j]
-proc `[]=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] = val
-proc `[]+=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] += val
-proc `[]-=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] -= val
 
 
 # for Vector subscription
@@ -49,26 +27,86 @@ proc `[]+=`*(self: var Vector, i, j: int, val: float64) {.inline.} =
   self.data[i] += val
 proc `[]-=`*(self: var Vector, i: int, val: float64) {.inline.} =
   self.data[i] -= val
+proc `*=`(self: var Vector, val: float64) {.inline.} =
+  for i in 0..<len(self):
+    self.data[i] *= val
+proc `/=`*(self: var Vector, val: float64) {.inline.} =
+   self *= 1.0/val
 
 
-proc toTensor*(X: seq[seq[seq[float64]]]): Tensor =
+# for Matrix subscription
+proc `[]`*(self: Matrix, i, j: int): var float64 {.inline.} =
+  result = self.data[i][j]
+proc `[]`*(self: Matrix, i:int): var seq[float64] {.inline.} = self.data[i]
+proc `[]=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] = val
+proc `[]+=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] += val
+proc `[]-=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] -= val
+proc `*=`(self: var Matrix, val: float64) {.inline.} =
+  for i in 0..<self.shape[0]:
+    for j in 0..<self.shape[1]:
+      self.data[i][j] *= val
+proc `/=`*(self: var Matrix, val: float64) {.inline.} =
+   self *= 1.0/val
+
+
+# for Tensor subsucription
+proc `[]`*(self: Tensor, i, j, k: int): var float64 {.inline.} =
+  result = self.data[i].data[j][k]
+proc `[]`*(self: Tensor, i: int): var Matrix {.inline.} = self.data[i]
+proc `[]=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i].data[j][k] = val
+proc `[]+=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i].data[j][k] += val
+proc `[]-=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i][j, k] -= val
+proc `*=`(self: var Tensor, val: float64) {.inline.} =
+  for i in 0..<self.shape[0]:
+    self.data[i] *= val
+proc `/=`*(self: var Tensor, val: float64) {.inline.} =
+   self *= 1.0/val
+
+
+proc toVector*(x: seq[float64]): Vector =
   new(result)
-  result.shape = [len(X), len(X[0]), len(X[0][0])]
-  result.data = X
-  return result
+  result.shape = [len(x)]
+  result.data = x
 
 
 proc toMatrix*(X: seq[seq[float64]]): Matrix =
   new(result)
   result.shape = [len(X), len(X[0])]
   result.data = X
-  return result
 
 
-proc zeros*(shape: array[1, int]): Vector =
+proc toTensor*(X: seq[seq[seq[float64]]]): Tensor =
+  new(result)
+  result.shape = [len(X), len(X[0]), len(X[0][0])]
+  result.data = newSeq[Matrix](result.shape[0])
+  for i, mat in X:
+    result.data[i] = toMatrix(mat)
+
+
+proc ones*(shape: array[2, int]): Matrix =
   new(result)
   result.shape = shape
-  result.data = newSeqWith(shape[0], 0.0)
+  result.data = newSeqWith(shape[0], newSeqWith(shape[1], 1.0))
+
+
+proc ones*(shape: array[3, int]): Tensor =
+  new(result)
+  result.shape = shape
+  result.data = newSeqWith(
+    shape[0], ones([shape[1], shape[2]])
+  )
+
+
+proc ones*(shape: array[1, int]): Vector =
+  new(result)
+  result.shape = shape
+  result.data = newSeqWith(shape[0], 1.0)
 
 
 proc zeros*(shape: array[2, int]): Matrix =
@@ -77,11 +115,17 @@ proc zeros*(shape: array[2, int]): Matrix =
   result.data = newSeqWith(shape[0], newSeqWith(shape[1], 0.0))
 
 
+proc zeros*(shape: array[1, int]): Vector =
+  new(result)
+  result.shape = shape
+  result.data = newSeqWith(shape[0], 0.0)
+
+
 proc zeros*(shape: array[3, int]): Tensor =
   new(result)
   result.shape = shape
   result.data = newSeqWith(
-    shape[0], newSeqWith(shape[1], newSeqWith(shape[2], 0.0))
+    shape[0], zeros([shape[1], shape[2]])
   )
 
 
@@ -138,3 +182,74 @@ proc norm*(X: Vector, p: int): float64 =
     if p == 0: result += float(X[i] != 0)
     else: result += abs(X[i])^p
   result = pow(result, 1.0/float(p))
+
+
+proc addRow*[Vec](self: var Matrix, x: Vec) =
+  self.data.add(newSeqWith(self.shape[1], 0.0))
+  for j in 0..<len(x):
+    self.data[^1][j] = x[j]
+  self.shape[0] += 1
+
+
+proc addCol*[Vec](self: var Matrix, x: Vec) =
+  for i in 0..<len(x):
+    self.data[i].add(x[i])
+  self.shape[1] += 1
+
+
+proc deleteRow*(self: var Matrix, i: int) = 
+  self.data.delete(i, i)
+  self.shape[0] -= 1
+
+
+proc add*(self: var Vector, val: float64) =
+  self.data.add(val)
+  self.shape[0] += 1
+
+
+proc delete*(self: var Vector, i: int) = 
+  self.data.delete(i, i)
+  self.shape[0] -= 1
+
+
+proc powerIteration*(X: Matrix, maxIter=20, tol=1e-4): 
+                    tuple[value: float64, vector: Vector] = 
+  let n = X.shape[0]
+  if n != X.shape[1]:
+    raise newException(ValueError, "X is not square matrix.")
+  var vector = zeros([n])
+  var cache = zeros([n])
+  var ev = 0.0
+  var evOld = 0.0
+  # init
+  for j in 0..<n:
+    vector[j] = 2*rand(1.0) - 1.0
+  vector /= norm(vector, 2)
+  # start power iteration
+  for it in 0..<maxIter:
+    ev = 0.0
+    # compute eigen value
+    for i in 0..<n:
+      var vi = 0.0
+      for j in 0..<n:
+        vi += X[i, j] * vector[j]
+      ev += vector[i] * vi
+      cache[i] = vi
+    for i in 0..<n:
+      vector[i] = cache[i]
+    vector /= norm(vector, 2)
+    if it > 0 and abs(ev-evOld) < tol:
+      break
+    evOld = ev
+  result = (ev, vector)
+
+
+when isMainModule:
+  let X = toMatrix(@[@[8.0, 1.0], @[4.0, 5.0]])
+  var eval: float64
+  var evec: Vector
+  for i in 0..<10:
+    (eval, evec) = powerIteration(X, 10, 0)
+    echo(eval)
+    echo(evec[0], " ", evec[1])
+    echo(norm(evec, 2))

--- a/src/nimfm/tensor.nim
+++ b/src/nimfm/tensor.nim
@@ -1,12 +1,16 @@
-import sequtils, random, math
+import sequtils, random, math, sugar, strformat
+import nimlapack
+
+# from system.nim
+template `^^`(s, i: untyped): untyped =
+  (when i is BackwardsIndex: s.len - int(i) else: int(i))
+
 
 type
-  Vector* = ref object
-    data: seq[float64]
-    shape*: array[1, int]
+  Vector* = seq[float64]
 
   Matrix* = ref object
-    data: seq[seq[float64]]
+    data: seq[Vector]
     shape*: array[2, int]
 
   Tensor* = ref object
@@ -14,85 +18,29 @@ type
     shape*: array[3, int]
 
 
-proc len*[T: Tensor|Matrix|Vector](self: T): int =
+proc `$`*[T: Matrix|Tensor](X: T): string =
+  result = "@[" & $X.data[0]
+  for vec in X.data[1..^1]:
+    result &= "\n  " & $vec
+  result &= "]"
+
+
+proc shape*[T](self: seq[T]): array[1, int] = [len(self)]
+
+
+proc len*[T: Tensor|Matrix](self: T): int =
   result = self.shape[0]
 
 
-# for Vector subscription
-proc `[]`*(self: Vector, i: int): var float64 {.inline.} =
-  result = self.data[i]
-proc `[]=`*(self: var Vector, i: int, val: float64) {.inline.} =
-  self.data[i] = val
-proc `[]+=`*(self: var Vector, i, j: int, val: float64) {.inline.} =
-  self.data[i] += val
-proc `[]-=`*(self: var Vector, i: int, val: float64) {.inline.} =
-  self.data[i] -= val
-proc `*=`(self: var Vector, val: float64) {.inline.} =
-  for i in 0..<len(self):
-    self.data[i] *= val
-proc `/=`*(self: var Vector, val: float64) {.inline.} =
-   self *= 1.0/val
-
-
-# for Matrix subscription
-proc `[]`*(self: Matrix, i, j: int): var float64 {.inline.} =
-  result = self.data[i][j]
-proc `[]`*(self: Matrix, i:int): var seq[float64] {.inline.} = self.data[i]
-proc `[]=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] = val
-proc `[]+=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] += val
-proc `[]-=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
-  self.data[i][j] -= val
-proc `*=`(self: var Matrix, val: float64) {.inline.} =
-  for i in 0..<self.shape[0]:
-    for j in 0..<self.shape[1]:
-      self.data[i][j] *= val
-proc `/=`*(self: var Matrix, val: float64) {.inline.} =
-   self *= 1.0/val
-
-
-# for Tensor subsucription
-proc `[]`*(self: Tensor, i, j, k: int): var float64 {.inline.} =
-  result = self.data[i].data[j][k]
-proc `[]`*(self: Tensor, i: int): var Matrix {.inline.} = self.data[i]
-proc `[]=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i].data[j][k] = val
-proc `[]+=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i].data[j][k] += val
-proc `[]-=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
-  self.data[i][j, k] -= val
-proc `*=`(self: var Tensor, val: float64) {.inline.} =
-  for i in 0..<self.shape[0]:
-    self.data[i] *= val
-proc `/=`*(self: var Tensor, val: float64) {.inline.} =
-   self *= 1.0/val
-
-
-proc toVector*(x: seq[float64]): Vector =
-  new(result)
-  result.shape = [len(x)]
-  result.data = x
-
-
-proc toMatrix*(X: seq[seq[float64]]): Matrix =
-  new(result)
-  result.shape = [len(X), len(X[0])]
-  result.data = X
-
-
-proc toTensor*(X: seq[seq[seq[float64]]]): Tensor =
-  new(result)
-  result.shape = [len(X), len(X[0]), len(X[0][0])]
-  result.data = newSeq[Matrix](result.shape[0])
-  for i, mat in X:
-    result.data[i] = toMatrix(mat)
+# initialization
+proc ones*(shape: array[1, int]): Vector =
+  result = newSeqWith(shape[0], 1.0)
 
 
 proc ones*(shape: array[2, int]): Matrix =
   new(result)
   result.shape = shape
-  result.data = newSeqWith(shape[0], newSeqWith(shape[1], 1.0))
+  result.data = newSeqWith(shape[0], ones([shape[1]]))
 
 
 proc ones*(shape: array[3, int]): Tensor =
@@ -103,22 +51,14 @@ proc ones*(shape: array[3, int]): Tensor =
   )
 
 
-proc ones*(shape: array[1, int]): Vector =
-  new(result)
-  result.shape = shape
-  result.data = newSeqWith(shape[0], 1.0)
+proc zeros*(shape: array[1, int]): Vector =
+  result = newSeqWith(shape[0], 0.0)
 
 
 proc zeros*(shape: array[2, int]): Matrix =
   new(result)
   result.shape = shape
-  result.data = newSeqWith(shape[0], newSeqWith(shape[1], 0.0))
-
-
-proc zeros*(shape: array[1, int]): Vector =
-  new(result)
-  result.shape = shape
-  result.data = newSeqWith(shape[0], 0.0)
+  result.data = newSeqWith(shape[0], zeros([shape[1]]))
 
 
 proc zeros*(shape: array[3, int]): Tensor =
@@ -127,6 +67,274 @@ proc zeros*(shape: array[3, int]): Tensor =
   result.data = newSeqWith(
     shape[0], zeros([shape[1], shape[2]])
   )
+
+
+# For Vector broadcasting
+# Vector-scalar in-place operations
+proc `+=`*[T](self: var seq[T], val: T) {.inline.} =
+  for i in 0..<len(self):
+    self[i] += val
+
+
+proc `-=`*[T, U](self: var seq[T], val: T) {.inline.} =
+  self += -val
+
+
+proc `*=`*[T](self: var seq[T], val: T) {.inline.} =
+  for i in 0..<len(self):
+    self[i] *= val
+
+
+proc `/=`*[T](self: var seq[T], val: T) {.inline.} =
+  for i in 0..<len(self):
+    self[i] /= val
+
+
+proc `[]=`*[T, U, V](self: var seq[T], x: HSlice[U, V], val: T) {.inline.} =
+  let a = self ^^ x.a
+  let b = self ^^ x.b
+  for i in a..b:
+    self[i] = val
+
+
+# seq[T]-scalar operations returning new seq[T]
+proc `+`*[T](vec: seq[T], val: T): seq[T] =
+  result = vec
+  result += val
+
+
+proc `-`*[T](vec: seq[T], val: T): seq[T] = vec + (-val)
+
+
+proc `*`*[T](vec: seq[T], val: T): seq[T] =
+  result = vec
+  result *= val
+
+
+proc `/`*[T](vec: seq[T], val: T): seq[T] =
+  result = vec
+  result /= val
+
+
+proc `-`*[T](vec: seq[T]): seq[T] =
+  result = vec * (-1)
+
+
+proc `+`*[T](val: T, vec: seq[T]): seq[T] = vec + val
+
+
+proc `-`*[T](val: T, vec: seq[T]): seq[T] = -(vec - val)
+
+
+proc `*`*[T](val: T, vec: seq[T]): seq[T] = vec * val
+
+
+proc `/`*[T](val: T, vec: seq[T]): seq[T] =
+  result = vec
+  for i, denom in result:
+    result[i] = val / denom
+
+
+# seq[T]-seq[T] in-place operations
+proc `+=`*[T](self: var seq[T], vec: seq[T]) {.inline.} =
+  if len(self) != len(vec):
+    raise newException(ValueError, "len(self) != len(vec).")
+  for i, val in vec:
+    self[i] += val
+
+
+proc `-=`*[T](self: var seq[T], vec: seq[T]) {.inline.} =
+  if len(self) != len(vec):
+    raise newException(ValueError, "len(self) != len(vec).")
+  for i, val in vec:
+    self[i] -= val
+
+
+proc `*=`*[T](self: var seq[T], vec: seq[T]) {.inline.} =
+  if len(self) != len(vec):
+    raise newException(ValueError, "len(self) != len(vec).")
+  for i, val in vec:
+    self[i] *= val
+
+
+proc `/=`*[T](self: var seq[T], vec: seq[T]) {.inline.} =
+  if len(self) != len(vec):
+    raise newException(ValueError, "len(self) != len(vec).")
+  for i, val in vec:
+    self[i] /= val
+
+
+# seq[T]-seq[T] operations returning new seq[T]
+proc `+`*[T](vec1, vec2: seq[T]): seq[T] =
+  result = vec1
+  result += vec2
+
+
+proc `-`*[T](vec1, vec2: seq[T]): seq[T] =
+  result = vec1
+  result -= vec2
+
+
+proc `*`*[T](vec1, vec2: seq[T]): seq[T] =
+  result = vec1
+  result *= vec2
+
+
+proc `/`*[T](vec1, vec2: seq[T]): seq[T] =
+  result = vec1
+  result /= vec2
+
+
+# for Matrix subscription
+proc `[]`*(self: Matrix, i, j: int): var float64 {.inline.} =
+  result = self.data[i][j]
+
+
+proc `[]`*(self: Matrix, i: int): var Vector {.inline.} = self.data[i]
+
+
+proc `[]=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] = val
+
+
+proc `[]+=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] += val
+
+
+proc `[]-=`*(self: var Matrix, i, j: int, val: float64) {.inline.} =
+  self.data[i][j] -= val
+
+
+proc `[]=`*[U1, V1, U2, V2](self: var Matrix, x: HSlice[U1, V1],
+                            y: HSlice[U2, V2], val: float64) {.inline.} =
+  let a1 = self ^^ x.a
+  let b1 = self ^^ x.b
+  let a2 = self[0] ^^ y.a
+  let b2 = self[0] ^^ y.b
+  for i in a1..b1:
+    for j in a2..b2:
+      self[i, j] = val
+
+
+# for Matrix broadcast
+# Matrix-scalar/vector in-place operations
+proc `+=`*[T: float64|Vector](self: var Matrix, val: T) {.inline.} =
+  for i in 0..<len(self):
+    self.data[i] += val
+
+
+proc `-=`*[T: float64|Vector](self: var Matrix, val: T) {.inline.} = self += (-val)
+
+
+proc `*=`*[T: float64|Vector](self: var Matrix, val: T) {.inline.} =
+  for i in 0..<len(self):
+    self.data[i] *= val
+
+
+proc `/=`*[T: float64|Vector](self: var Matrix, val: T) {.inline.} =
+  for i in 0..<len(self):
+    self.data[i] /= val
+
+
+# Matrix-scalar/vector operations returning new Matrix
+proc `-`*(mat: Matrix): Matrix =
+  new(result)
+  deepCopy(result, mat)
+  for i in 0..<len(result):
+    result.data[i] *= -1
+
+
+proc `+`*[T: float64|Vector](mat: Matrix, val: T): Matrix =
+  new(result)
+  deepCopy(result, mat)
+  for i in 0..<len(result):
+    result.data[i] += val
+
+
+proc `-`*[T: float64|Vector](mat: Matrix, val: T): Matrix = mat + (-val)
+
+
+proc `*`*[T: float64|Vector](mat: Matrix, val: T): Matrix = 
+  new(result)
+  deepCopy(result, mat)
+  for i in 0..<len(result):
+    result.data[i] *= val
+
+
+proc `/`*[T: float64|Vector](mat: Matrix, val: T): Matrix =
+  new(result)
+  deepCopy(result, mat)
+  for i in 0..<len(result):
+    result.data[i] /= val
+
+
+proc `+`*[T: float64|Vector](val: T, mat: Matrix): Matrix = mat + val
+
+
+proc `-`*[T: float64|Vector](val: T, mat: Matrix): Matrix =
+  new(result)
+  deepCopy(result, mat)
+  result *= -1
+  result += val
+
+
+proc `*`*[T: float64|Vector](val: T, mat: Matrix): Matrix = mat * val
+
+
+proc `/`*[T: float64|Vector](val: T, mat: Matrix): Matrix =
+  new(result)
+  deepCopy(result, mat)
+  for i in 0..<result.shape[0]:
+    for j in 0..<result.shape[1]:
+      result[i, j] = val / result[i, j]
+
+
+proc transpose*(mat: Matrix): Matrix =
+  new(result)
+  result.shape = [mat.shape[1], mat.shape[0]]
+  result.data = newSeqWith(mat.shape[1], zeros([mat.shape[0]]))
+  for i in 0..<result.shape[0]:
+    for j in 0..<result.shape[1]:
+      result[i, j] = mat[j, i]
+
+
+proc T*(mat: Matrix): Matrix = transpose(mat)
+
+
+# for Tensor subsucription
+proc `[]`*(self: Tensor, i, j, k: int): var float64 {.inline.} =
+  result = self.data[i].data[j][k]
+
+
+proc `[]`*(self: Tensor, i: int): var Matrix {.inline.} = self.data[i]
+
+
+proc `[]=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i].data[j][k] = val
+
+
+proc `[]+=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i].data[j][k] += val
+
+
+proc `[]-=`*(self: var Tensor, i, j, k: int, val: float64) {.inline.} =
+  self.data[i][j, k] -= val
+
+
+proc toMatrix*(X: seq[seq[float64]]): Matrix =
+  new(result)
+  result.shape = [len(X), len(X[0])]
+  result.data = newSeq[Vector](len(X))
+  for i, vec in X:
+    result.data[i] = vec
+
+
+proc toTensor*(X: seq[seq[seq[float64]]]): Tensor =
+  new(result)
+  result.shape = [len(X), len(X[0]), len(X[0][0])]
+  result.data = newSeq[Matrix](result.shape[0])
+  for i, mat in X:
+    result.data[i] = toMatrix(mat)
 
 
 proc randomNormal*(shape: array[3, int], loc = 0.0, scale = 1.0): Tensor =
@@ -174,11 +382,11 @@ proc norm*(X: Matrix, p: int): float64 =
   result = pow(result, 1.0/float(p))
 
 
-proc norm*(X: Vector, p: int): float64 =
+proc norm*[T](X: T, p: int): float64 =
   result = 0.0
   if p < 0:
     raise newException(ValueError, "p < 0.")
-  for i in 0..<X.shape[0]:
+  for i in 0..<len(X):
     if p == 0: result += float(X[i] != 0)
     else: result += abs(X[i])^p
   result = pow(result, 1.0/float(p))
@@ -202,18 +410,199 @@ proc deleteRow*(self: var Matrix, i: int) =
   self.shape[0] -= 1
 
 
-proc add*(self: var Vector, val: float64) =
-  self.data.add(val)
-  self.shape[0] += 1
+proc sum*[T: Matrix|Tensor](X: T): float64 = sum(X.data)
 
 
-proc delete*(self: var Vector, i: int) = 
-  self.data.delete(i, i)
-  self.shape[0] -= 1
+proc prod*[T: Matrix|Tensor](X: T): float64 = prod(X.data)
 
 
-proc powerIteration*(X: Matrix, maxIter=20, tol=1e-4): 
-                    tuple[value: float64, vector: Vector] = 
+proc dot(x, y: float64): float64 {.inline.} = x*y
+
+
+proc dot*[T: Vector|Matrix|Tensor](X, Y: T): float64 {.inline.} =
+  ## Computes dot product between two vectors/matrices/tensors
+  if X.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  result = 0.0
+  for i in 0..<len(X):
+    result += dot(X[i], Y[i])
+
+
+# element-wise operation between two matrices/tensors
+# in-place operations
+proc `+=`*[T: Matrix|Tensor](self: var T, Y: T) =
+  ## Compute in-place row-wise/element-wise addition
+  if self.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  for i in 0..<len(self):
+    self.data[i] += Y.data[i]
+
+
+proc `-=`*[T: Matrix|Tensor](self: var T, Y: T) =
+  ## Compute in-place row-wise/element-wise subtraction
+  if self.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  for i in 0..<len(self):
+    self.data[i] -= Y.data[i]
+
+
+proc `*=`*[T: Matrix|Tensor](self: var T, Y: T) =
+  ## Compute in-place row-wise/element-wise product
+  if self.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  for i in 0..<len(self):
+    self.data[i] *= Y.data[i]
+
+
+proc `/=`*[T: Matrix|Tensor](self: var T, Y: T) =
+  ## Compute in-place row-wise/element-wise division
+  if self.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  for i in 0..<len(self):
+    self.data[i] /= Y.data[i]
+
+
+# returning new matrix/tensor operations
+proc `+`*[T: Matrix|Tensor](X, Y: T): T {.inline.} =
+  ## Computes element-wise addition
+  if X.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  new(result)
+  result.shape = X.shape
+  result.data.setLen(len(X))
+  for i in 0..<len(X):
+    result.data[i] = X.data[i] + Y.data[i]
+
+
+proc `-`*[T: Matrix|Tensor](X, Y: T): T {.inline.} =
+  ## Computes element-wise subtraction
+  if X.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  new(result)
+  result.shape = X.shape
+  result.data.setLen(len(X))
+  for i in 0..<len(X):
+    result.data[i] = X.data[i] - Y.data[i]
+
+
+proc `*`*[T: Matrix|Tensor](X, Y: T): T {.inline.} =
+  ## Computes element-wise product
+  if X.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  new(result)
+  result.shape = X.shape
+  result.data.setLen(len(X))
+  for i in 0..<len(X):
+    result.data[i] = X.data[i] * Y.data[i]
+
+
+proc `/`*[T: Matrix|Tensor](X, Y: T): T {.inline.} =
+  ## Computes element-wise division
+  if X.shape != Y.shape:
+    raise newException(ValueError, "shape(X) != shape(Y).")
+  new(result)
+  result.shape = X.shape
+  result.data.setLen(len(X))
+  for i in 0..<len(X):
+    result.data[i] = X.data[i] / Y.data[i]
+
+
+proc mvmul*(mat: Matrix, vec: Vector, result: var Vector) =
+  ## Multpies (n, m) matrix and (m, ) vector
+  ## and substitutes output into result
+  if mat.shape[1] != len(vec):
+    raise newException(ValueError, "mat.shape[1] != len(vec).")
+  if len(result) != mat.shape[0]:
+    raise newException(ValueError, "len(result) != mat.shape[0].")
+  result[.. ^1] = 0.0
+  for i, mati in mat.data:
+    result[i] = dot(mati, vec)
+
+
+proc mvmul*(mat: Matrix, vec: Vector): Vector =
+  ## Multpies (n, m) matrix and (m, ) vector
+  ## Returns new (n, ) vector
+  if mat.shape[1] != len(vec):
+    raise newException(ValueError, "mat.shape[1] != len(vec).")
+  result = newSeqWith(len(mat), 0.0)
+  for i, mati in mat.data:
+    result[i] = dot(mati, vec)
+
+
+proc vmmul*(vec: Vector, mat: Matrix, result: var Vector) =
+  ## Multpies (n, ) vector and (n, m) matrix
+  ## and substitutes output into result
+  if mat.shape[0] != len(vec):
+    raise newException(ValueError, "mat.shape[0] != len(vec).")
+  if len(result) != mat.shape[1]:
+    raise newException(ValueError, "len(result) != nat.shape[1].")
+  result[.. ^1] = 0.0
+  for i, mati in mat.data:
+    result[i] = dot(mati, vec)
+
+
+proc vmmul*(vec: Vector, mat: Matrix): Vector =
+  ## Multpies (n, ) vector and (n, m) matrix
+  ## Returns (m, ) vector
+  if mat.shape[0] != len(vec):
+    raise newException(ValueError, "mat.shape[0] != len(vec).")
+  result = newSeqWith(mat.shape[1], 0.0)
+  for i, mati in mat.data:
+    result[i] = dot(mati, vec)
+
+
+# Naive and too slow
+proc matmul*(mat1, mat2: Matrix, result: var Matrix) =
+  ## Multpies mat1: (n, k) matrix and mat2: (k, m) matrix
+  ## and substitutes output into result
+  if mat1.shape[1] != mat2.shape[0]:
+    raise newException(ValueError, "mat1.shape[1] != mat2.shape[0]")
+  let
+    n = mat1.shape[0]
+    m = mat2.shape[1]
+  if result.shape != [n, m]:
+    raise newException(ValueError, fmt"out.shape != [{n}, {m}].")
+  # initialization
+  for i in 0..<n:
+    for j in 0..<m:
+      result[i, j] = 0.0
+  for i in 0..<n:
+    for k in 0..<mat1.shape[1]:
+      for j in 0..<m:
+        result[i, j] += mat1[i, k] * mat2[k, j]
+
+
+# Naive and too slow
+proc matmul*(mat1, mat2: Matrix): Matrix =
+  ## Multpies mat1: (n, k) matrix and mat2: (k, m) matrix
+  ## Returns new (n, m) matrix
+  if mat1.shape[1] != mat2.shape[0]:
+    raise newException(ValueError, "mat1.shape[1] != mat2.shape[0]")
+  let
+    n = mat1.shape[0]
+    m = mat2.shape[1]
+  new(result)
+  result.shape = [n, m]
+  result.data = newSeqWith(n, zeros([m]))
+  matmul(mat1, mat2, result)
+
+
+# Modified Gram-Schmidt
+proc orthogonalize*(X: var Matrix, n: int) =
+  ## Orthogonalizes rows in X.
+  for i in 0..<n:
+    for j in 0..<i:
+      var dot = 0.0
+      for k in 0..<X.shape[1]:
+        dot += X[i, k] * X[j, k]
+      for k in 0..<X.shape[1]:
+        X[i, k] -= dot * X[j, k]
+    X[i] /= norm(X[i], 2)
+
+
+proc powerIteration*(X: Matrix, maxIter=100, tol=1e-4): 
+                    tuple[value: float64, vector: Vector] =
+  ## Computes the dominate eigenvalue and corresponding eigenvector of X
   let n = X.shape[0]
   if n != X.shape[1]:
     raise newException(ValueError, "X is not square matrix.")
@@ -244,12 +633,34 @@ proc powerIteration*(X: Matrix, maxIter=20, tol=1e-4):
   result = (ev, vector)
 
 
-when isMainModule:
-  let X = toMatrix(@[@[8.0, 1.0], @[4.0, 5.0]])
-  var eval: float64
-  var evec: Vector
-  for i in 0..<10:
-    (eval, evec) = powerIteration(X, 10, 0)
-    echo(eval)
-    echo(evec[0], " ", evec[1])
-    echo(norm(evec, 2))
+proc dsyev*(X: var Matrix, eigs: var Vector, columnWise=true) =
+  ## Computes eigendecomposition of X
+  if X.shape[0] != X.shape[1]:
+    raise newException(ValueError, "X is not squared matrix.")
+  let 
+    jobs: cstring = "V"
+    uplo: cstring = "U"
+    n: int32 = int32(X.shape[0])
+    info: int32 = 0
+    lda: int32 = n
+  var
+    lwork: int32 = -1
+    work: seq[float64] = @[0.0]
+  # Rows of X might not be allocated continuously
+  var A = newSeqWith(prod(X.shape), 0.0)
+  # Fortran order
+  for i in 0..<n:
+    for j in i..<n:
+      A[i+j*n] = X[i, j]
+  # get optimal work size
+  dsyev(jobs, uplo, n.unsafeAddr, A[0].unsafeAddr, lda.unsafeAddr,
+        eigs[0].unsafeAddr, work[0].addr, lwork.addr, info.unsafeAddr)
+  lwork = int32(work[0])
+  work.setLen(lwork)
+  # eigen decomposition
+  dsyev(jobs, uplo, n.unsafeAddr, A[0].unsafeAddr, lda.unsafeAddr,
+        eigs[0].addr, work[0].addr, lwork.addr, info.unsafeAddr)
+  for i in 0..<n:
+    for j in 0..<n:
+      if columnWise: X[i, j] = A[i+j*n]
+      else: X[j, i] = A[i+j*n] 

--- a/src/nimfm/utils.nim
+++ b/src/nimfm/utils.nim
@@ -1,4 +1,4 @@
-import tables, algorithm, sequtils, sugar, math
+import tables, algorithm, sequtils, math
 
 type
   LabelEncoderObj[T] = object
@@ -16,6 +16,18 @@ proc argsort*[T](a: T, order=SortOrder.Ascending): seq[int] =
     sort(result,  proc(i, j: int ): int = cmp(a[i], a[j]))
   of SortOrder.Descending:
     sort(result,  proc(i, j: int ): int = -cmp(a[i], a[j]))
+
+
+proc argmin*[T](a: seq[T]): int =
+  result = 0
+  for i in 1..<len(a):
+    if a[i] < a[result]: result = i
+
+
+proc argmax*[T](a: seq[T]): int =
+  result = 0
+  for i in 1..<len(a):
+    if a[i] > a[result]: result = i
 
 
 proc expit*(x: float64): float64  =  exp(min(0.0, x)) / (1.0 + exp(-abs(x)))

--- a/tests/cd_slow.nim
+++ b/tests/cd_slow.nim
@@ -1,4 +1,4 @@
-import nimfm/loss, nimfm/tensor, nimfm/optimizers/base
+import nimfm/loss, nimfm/tensor, nimfm/optimizers/optimizer_base
 import sequtils, math
 import fm_slow, kernels_slow, fit_linear_slow, utils
 
@@ -6,7 +6,7 @@ type
   CoordinateDescentSlow* = ref object of BaseCSCOptimizer
     ## Coordinate descent solver for test.
 
-proc newCoordinateDescentSlow*(maxIter = 100, verbose = true, tol = 1e-3):
+proc newCoordinateDescentSlow*(maxIter = 100, verbose = 1, tol = 1e-3):
                                CoordinateDescentSlow =
   result = CoordinateDescentSlow(maxIter: maxIter, tol: tol, verbose: verbose)
 
@@ -30,7 +30,7 @@ proc predict(P: Tensor, w: Vector, intercept: float64, X: Matrix,
   for order in 0..<nOrders:
     for s in 0..<nComponents:
       for i in 0..<nSamples:
-        let anova = anovaSlow(X, P, i, degree-order, order,
+        let anova = anovaSlow(X, P[order], i, degree-order,
                               s, nFeatures, nAugments)
         yPred[i] += anova
 
@@ -66,7 +66,7 @@ proc update(P: Tensor, X: Matrix, y: seq[float64], yPred: seq[float64],
   
   computeDerivatives(P, X, dA, degree, order, s, j, nAugments)
   for i in 0..<nSamples:
-    result += loss.dloss(yPred[i], y[i]) * dA[i]
+    result += loss.dloss(y[i], yPred[i]) * dA[i]
     invStepSize += dA[i]^2
 
   invStepSize = invStepSize*loss.mu + beta

--- a/tests/cd_slow.nim
+++ b/tests/cd_slow.nim
@@ -1,14 +1,14 @@
-import nimfm/loss, nimfm/tensor, nimfm/optimizers/optimizer_base
+import nimfm/tensor, nimfm/optimizers/optimizer_base
 import sequtils, math
 import fm_slow, kernels_slow, fit_linear_slow, utils
 
 type
-  CoordinateDescentSlow* = ref object of BaseCSCOptimizer
+  CDSlow* = ref object of BaseCSCOptimizer
     ## Coordinate descent solver for test.
 
-proc newCoordinateDescentSlow*(maxIter = 100, verbose = 1, tol = 1e-3):
-                               CoordinateDescentSlow =
-  result = CoordinateDescentSlow(maxIter: maxIter, tol: tol, verbose: verbose)
+proc newCDSlow*(maxIter = 100, verbose = 1, tol = 1e-3):
+                               CDSlow =
+  result = CDSlow(maxIter: maxIter, tol: tol, verbose: verbose)
 
 
 proc predict(P: Tensor, w: Vector, intercept: float64, X: Matrix,
@@ -57,9 +57,9 @@ proc computeDerivatives(P: Tensor, X: Matrix, dA: var Vector,
       dA[i] *= X[i, j]
 
 
-proc update(P: Tensor, X: Matrix, y: seq[float64], yPred: seq[float64],
-            beta: float64, degree, order, s, j, nAugments: int,
-            loss: LossFunction, dA: var Vector): float64 =
+proc update[L](P: Tensor, X: Matrix, y: seq[float64], yPred: seq[float64],
+               beta: float64, degree, order, s, j, nAugments: int,
+               loss: L, dA: var Vector): float64 =
   result = beta * P[order, s, j]
   let nSamples = X.shape[0]
   var invStepSize: float64 = 0.0
@@ -73,10 +73,10 @@ proc update(P: Tensor, X: Matrix, y: seq[float64], yPred: seq[float64],
   result /= invStepSize
 
 
-proc epoch(X: Matrix, y: seq[float64], yPred: var seq[float64],
-           P: var Tensor, beta: float64, degree, order, nAugments: int,
-           loss: LossFunction, dA: var Vector, w: Vector,
-           intercept: float64): float64 =
+proc epoch[L](X: Matrix, y: seq[float64], yPred: var seq[float64],
+              P: var Tensor, beta: float64, degree, order, nAugments: int,
+              loss: L, dA: var Vector, w: Vector,
+              intercept: float64): float64 =
   result = 0.0
   let nFeatures = X.shape[1]
   let nComponents = P.shape[1]
@@ -90,8 +90,8 @@ proc epoch(X: Matrix, y: seq[float64], yPred: var seq[float64],
       predict(P, w, intercept, X, yPred, degree)
 
 
-proc fit*(self: CoordinateDescentSlow, X: Matrix, y: seq[float64],
-          fm: var FMSlow) =
+proc fit*[L](self: CDSlow, X: Matrix, y: seq[float64],
+             fm: var FMSlow[L]) =
   fm.init(X)
   let y = fm.checkTarget(y)
   let
@@ -105,7 +105,7 @@ proc fit*(self: CoordinateDescentSlow, X: Matrix, y: seq[float64],
     fitLinear = fm.fitLinear
     fitIntercept = fm.fitIntercept
     nAugments = fm.nAugments
-    loss = newLossFunction(fm.loss)
+    loss = fm.loss
 
   # caches
   var

--- a/tests/cfm_slow.nim
+++ b/tests/cfm_slow.nim
@@ -1,7 +1,6 @@
 import nimfm/loss, nimfm/tensor, nimfm/metrics, nimfm/convex_factorization_machine
 import nimfm/fm_base
 import sugar, sequtils, math
-import utils
 
 
 type

--- a/tests/cfm_slow.nim
+++ b/tests/cfm_slow.nim
@@ -4,13 +4,13 @@ import sugar, sequtils, math
 
 
 type
-  CFMSlow* = ref ConvexFactorizationMachineObj
+  CFMSlow*[L] = ref ConvexFactorizationMachineObj[L]
 
 
-proc newCFMSlow*(
+proc newCFMSlow*[L](
   task: TaskKind, maxComponents = 30, alpha0 = 1e-6, alpha = 1e-3,
-  beta = 1e-5, loss = SquaredHinge, fitIntercept = true, fitLinear = true,
-  ignoreDiag=true, warmStart = false): CFMSlow =
+  beta = 1e-5, eta=1000.0, loss: L = newSquared(), fitIntercept = true, fitLinear = true,
+  ignoreDiag=true, warmStart = false): CFMSlow[L] =
   new(result)
   result.task = task
   result.degree = 2
@@ -22,9 +22,8 @@ proc newCFMSlow*(
   result.alpha0 = alpha0
   result.alpha = alpha
   result.beta = beta
-  case task
-  of regression: result.loss = Squared
-  of classification: result.loss = loss
+  result.eta = eta
+  result.loss = loss
   result.fitIntercept = fitIntercept
   result.fitLinear = fitLinear
   result.ignoreDiag = ignoreDiag

--- a/tests/cfm_slow.nim
+++ b/tests/cfm_slow.nim
@@ -1,0 +1,95 @@
+import nimfm/loss, nimfm/tensor, nimfm/metrics, nimfm/convex_factorization_machine
+import nimfm/fm_base
+import sugar, sequtils, math
+import utils
+
+
+type
+  CFMSlow* = ref ConvexFactorizationMachineObj
+
+
+proc newCFMSlow*(
+  task: TaskKind, maxComponents = 30, alpha0 = 1e-6, alpha = 1e-3,
+  beta = 1e-5, loss = SquaredHinge, fitIntercept = true, fitLinear = true,
+  ignoreDiag=true, warmStart = false): CFMSlow =
+  new(result)
+  result.task = task
+  result.degree = 2
+  if maxComponents < 1:
+    raise newException(ValueError, "maxComponents < 1.")
+  result.maxComponents = maxComponents
+  if alpha0 < 0 or alpha < 0 or beta < 0:
+    raise newException(ValueError, "Regularization strength < 0.")
+  result.alpha0 = alpha0
+  result.alpha = alpha
+  result.beta = beta
+  case task
+  of regression: result.loss = Squared
+  of classification: result.loss = loss
+  result.fitIntercept = fitIntercept
+  result.fitLinear = fitLinear
+  result.ignoreDiag = ignoreDiag
+  result.warmStart = warmStart
+  result.degree = 2
+  result.isInitalized = false
+  result.lams = zeros([maxComponents])
+
+
+proc init*(self: CFMSlow, X: Matrix, force=false) =
+  ## Initializes the factorization machine.
+  ## If force=false, fm is already initialized, and warmStart=true,
+  ## fm will not be initialized.
+  if force or not (self.warmStart and self.isInitalized):
+    let nFeatures: int = X.shape[1]
+    self.w = zeros([nFeatures])
+    self.P = zeros([self.maxComponents, nFeatures])
+    self.intercept = 0.0
+  self.isInitalized = true
+
+
+proc decisionFunction*(self: CFMSlow, X: Matrix): seq[float64] =
+  self.checkInitialized()
+  let nSamples: int = X.shape[0]
+  let nFeatures = X.shape[1]
+  result = newSeqWith(nSamples, self.intercept)
+
+  for i in 0..<nSamples:
+    for j in 0..<nFeatures:
+      result[i] += self.w[j] * X[i, j]
+  
+  if nFeatures != self.P.shape[1]:
+    raise newException(ValueError, "Invalid nFeatures.")
+
+  for i in 0..<nSamples:
+    for s in 0..<len(self.lams):
+      var kernel = 0.0
+      if self.ignoreDiag:
+        for j1 in 0..<nFeatures:
+          for j2 in j1+1..<nFeatures:
+            kernel += X[i, j1] * X[i, j2] * self.P[s, j1] * self.P[s, j2]
+      else:
+        for j in 0..<nFeatures:
+          kernel += self.P[s, j] * X[i, j]
+        kernel = kernel * kernel
+      result[i] += self.lams[s] * kernel
+
+
+proc predict*(self: CFMSlow, X: Matrix): seq[int] =
+  result = decisionFunction(self, X).map(x=>sgn(x))
+
+
+proc checkTarget*(self: CFMSlow, y: seq[SomeNumber]): seq[float64] =
+  case self.task
+  of classification:
+    result = y.map(x => float(sgn(x)))
+  of regression:
+    result = y.map(x => float(x))
+
+
+proc score*(self: CFMSlow, X: Matrix, y: seq[float64]): float64 =
+  let yPred = self.decisionFunction(X)
+  case self.task
+  of regression:
+    result = rmse(y, yPred)
+  of classification:
+    result = accuracy(y.map(x=>sgn(x)), yPred.map(x=>sgn(x)))

--- a/tests/fit_linear_slow.nim
+++ b/tests/fit_linear_slow.nim
@@ -14,7 +14,7 @@ proc fitLinearCD*(w: var Vector, X: Matrix, y: seq[float64],
   for j in 0..<nFeatures:
     update = alpha * w[j]
     for i in 0..<nSamples:
-      update += loss.dloss(yPred[i], y[i]) * X[i, j]
+      update += loss.dloss(y[i], yPred[i]) * X[i, j]
     invStepSize = loss.mu * colNormSq[j] + alpha
     update /= invStepSize
     result += abs(update)
@@ -28,7 +28,7 @@ proc fitInterceptCD*(intercept: var float64, y: seq[float64],
                      alpha0: float64, loss: LossFunction): float64 =
   result = alpha0 * intercept
   for i in 0..<nSamples:
-    result += loss.dloss(yPred[i], y[i])
+    result += loss.dloss(y[i], yPred[i])
   result /= loss.mu * float(nSamples) + alpha0
   intercept -= result
   for i in 0..<nSamples:

--- a/tests/fit_linear_slow.nim
+++ b/tests/fit_linear_slow.nim
@@ -1,9 +1,9 @@
 import nimfm/loss, nimfm/tensor
 
 
-proc fitLinearCD*(w: var Vector, X: Matrix, y: seq[float64],
-                  yPred: var seq[float64], colNormSq: Vector,
-                  alpha: float64, loss: LossFunction): float64 =
+proc fitLinearCD*[L](w: var Vector, X: Matrix, y: seq[float64],
+                     yPred: var seq[float64], colNormSq: Vector,
+                     alpha: float64, loss: L): float64 =
   result = 0.0
   let nSamples = X.shape[0]
   let nFeatures = X.shape[1]
@@ -23,9 +23,9 @@ proc fitLinearCD*(w: var Vector, X: Matrix, y: seq[float64],
       yPred[i] -= update * X[i, j]
 
 
-proc fitInterceptCD*(intercept: var float64, y: seq[float64],
-                     yPred: var seq[float64], nSamples: int,
-                     alpha0: float64, loss: LossFunction): float64 =
+proc fitInterceptCD*[L](intercept: var float64, y: seq[float64],
+                        yPred: var seq[float64], nSamples: int,
+                        alpha0: float64, loss: L): float64 =
   result = alpha0 * intercept
   for i in 0..<nSamples:
     result += loss.dloss(y[i], yPred[i])

--- a/tests/fm_slow.nim
+++ b/tests/fm_slow.nim
@@ -1,6 +1,9 @@
 import nimfm/loss, nimfm/tensor, nimfm/metrics, nimfm/factorization_machine
+import nimfm/fm_base
 import sugar, random, sequtils, math
 import utils
+
+export nAugments
 
 
 type
@@ -41,24 +44,6 @@ proc newFMSlow*(task: TaskKind, degree = 2, n_components = 30, alpha0 = 1e-6,
   result.randomState = randomState
   result.scale = scale
   result.isInitalized = false
-
-
-proc nAugments*(self: FMSlow): int =
-  case self.fitLower
-  of explicit, none:
-    result = 0
-  of augment:
-    result = if self.fitLinear: self.degree-2 else: self.degree-1
-
-
-proc nOrders(self: FMSlow): int =
-  if self.degree == 1: result = 0
-  else:
-    case self.fitLower
-    of explicit:
-      result = self.degree-1
-    of none, augment:
-      result = 1
 
 
 proc decisionFunction*(self: FMSlow, X: Matrix): seq[float64] =

--- a/tests/greedy_cd_slow.nim
+++ b/tests/greedy_cd_slow.nim
@@ -1,6 +1,6 @@
 import nimfm/loss, nimfm/tensor, nimfm/optimizers/optimizer_base
 from nimfm/fm_base import checkTarget, checkInitialized
-import sequtils, math, strformat, strutils
+import sequtils, math
 import fit_linear_slow, cfm_slow, kernels_slow
 
 type

--- a/tests/greedy_cd_slow.nim
+++ b/tests/greedy_cd_slow.nim
@@ -1,0 +1,248 @@
+import nimfm/loss, nimfm/tensor, nimfm/optimizers/optimizer_base
+from nimfm/fm_base import checkTarget, checkInitialized
+import sequtils, math, strformat, strutils
+import fit_linear_slow, cfm_slow, kernels_slow
+
+type
+  GCDSlow* = ref object of BaseCSCOptimizer
+    ## Greedy coordinate descent solver for convex factorization machines.
+    ## In this solver, the regularization for interaction is not 
+    ## squared Frobenius norm for P but the trace norm for interaction weight
+    ## matrix.
+    maxIterInner: int
+    maxIterPower: int
+    nRefitting: int
+    fullyRefit: bool
+    tolPower: float64
+
+
+proc predict(P: Matrix, w, lams: Vector, intercept: float64, X: Matrix,
+             yPred: var seq[float64], K: Matrix, degree: int) =
+  let
+    nSamples = X.shape[0]
+    nFeatures = X.shape[1]
+    nComponents = P.shape[0]
+  for i in 0..<nSamples:
+    yPred[i] = intercept
+
+  for j in 0..<nFeatures:
+    for i in 0..<nSamples:
+      yPred[i] += w[j] * X[i, j]
+
+  for s in 0..<nComponents:
+    if lams[s] == 0: continue
+    for i in 0..<nSamples:
+      yPred[i] += lams[s] * K[s, i]
+
+
+proc newGCDSlow*(
+  maxIter = 100, maxIterInner=100, nRefitting=10, fullyRefit=false,
+  verbose = 2, tol = 1e-7, maxIterPower = 100, tolPower = 1e-6): GCDSlow =
+  result = GCDSlow(
+    maxIter: maxIter, maxIterInner: maxIterInner, nRefitting: nRefitting,
+    fullyRefit: fullyRefit, tol: tol, verbose: verbose,
+    maxIterPower: maxIterPower, tolPower: tolPower)
+
+
+proc fitLams(lams: var Vector, s: int, beta: float64,
+             K: Matrix, dL: Vector, mu: float64) {.inline.} =
+  let nSamples = K.shape[1]
+  var
+    update = 0.0
+    invStepSize = 0.0
+    norm = 0.0
+  for i in 0..<nSamples:
+    update += dL[i] * K[s, i]
+    norm += K[s, i]^2
+  invStepSize = mu * norm
+  lams[s] -= update / invStepSize
+  # soft thresholding
+  if (lams[s] - beta / invStepSize) > 0:
+    lams[s] -= beta/invStepSize
+  elif (lams[s] + beta / invStepSize) < 0:
+    lams[s] += beta/invStepSize
+  else:
+    lams[s] = 0
+
+
+proc refitDiag(X: Matrix, y: seq[float64], yPred: var seq[float64], P: Matrix,
+               lams: var Vector, beta: float64, loss: LossFunction, K: Matrix, 
+               dL: var Vector, w: Vector, intercept: float64): int =
+  let nSamples = len(y)
+  result = 0
+  for s in 0..<len(lams):
+    if lams[s] != 0.0:
+      for i in 0..<nSamples:
+        dL[i] = loss.dloss(y[i], yPred[i])
+      fitLams(lams, s, beta, K, dL, loss.mu)
+      predict(P, w, lams, intercept, X, yPred, K, 2)
+      if lams[s] != 0: result += 1
+
+
+proc fitZ(self: GCDSlow, X: Matrix, y: seq[float64],
+          yPred: var seq[float64], P: var Matrix, lams: var Vector,
+          beta: float64, loss: LossFunction, K: var Matrix,
+          p, dL: var Vector, maxComponents, verbose: int,
+          ignoreDiag: bool, XTRX: var Matrix,
+          w: Vector, intercept: float64): float64 =
+  var nComponents = 0
+  let nSamples = X.shape[0]
+  let nFeatures = X.shape[1]
+  var lossOld = 0.0
+  var addBase = false
+  var evalue = 0.0
+  var sNew: int
+  for s in 0..<len(lams):
+    if lams[s] != 0.0: nComponents += 1
+
+  for i in 0..<nSamples:
+    lossOld += loss.loss(y[i], yPred[i])
+  for s in 0..<nComponents:
+    lossOld += beta * abs(lams[s])
+  lossOld /= float(nSamples)
+
+  for it in 0..<self.maxIterInner:
+    result = 0.0
+    addBase = false
+    predict(P, w, lams, intercept, X, yPred, K, 2)
+    # add new base (dominate eigenvector)
+    if nComponents < maxComponents:
+      # compute XTRX
+      for j1 in 0..<nFeatures:
+        for j2 in 0..<nFeatures:
+          XTRX[j1, j2] = 0.0
+      for i in 0..<nSamples:
+        dL[i]= loss.dloss(y[i], yPred[i])
+        for j1 in 0..<nFeatures:
+          for j2 in 0..<nFeatures:
+            XTRX[j1, j2] += dL[i] * X[i, j1] * X[i, j2]
+      if ignoreDiag:
+        for i in 0..<nSamples:
+          for j in 0..<nFeatures:
+            XTRX[j, j] -= dL[i] * X[i, j]^2
+        for j1 in 0..<nFeatures:
+          for j2 in 0..<nFeatures:
+            XTRX[j1, j2] *= 0.5
+      # compute dominate eigen vector
+      (evalue, p) = powerIteration(XTRX, self.maxIterPower, self.tol)
+      # determine the row index and substitute
+      for s in 0..<len(lams):
+        if lams[s] == 0.0:
+          sNew = s
+          break
+      for j in 0..<nFeatures:
+        P[sNew, j] = p[j]
+      for i in 0..<nSamples:
+        if ignoreDiag:
+          K[sNew, i] = anovaSlow(X, P, i, 2, sNew, nFeatures, 0)
+        else:
+          K[sNew, i] = polySlow(X, P, i, 2, sNew, nFeatures, 0)
+      # fit lams[sNew]
+      fitLams(lams, sNew, beta, K, dL, loss.mu)
+      predict(P, w, lams, intercept, X, yPred, K, 2)
+      if lams[sNew] != 0.0:
+        nComponents += 1
+        addBase = true
+    
+    # refitting
+    if (it+1) mod self.nRefitting == 0:
+      # diagonal refitting
+      if not self.fullyRefit:
+        nComponents = refitDiag(X, y, yPred, P, lams, beta, loss, K, dL,
+                                w, intercept)
+      else:
+        raise newException(ValueError, "Not implemented, ToDo.")
+    # stopping criterion
+    if addBase or (it+1) mod self.nRefitting == 0:
+      # compute objective for stopping criterion
+      result = 0.0
+      for s in 0..<len(lams):
+        result += abs(lams[s])
+      result *= beta / float(nSamples)
+      for i in 0..<nSamples:
+        result += loss.loss(y[i], yPred[i])
+      result /= float(nSamples)
+      
+      # stopping criterion
+      if abs(result - lossOld) < self.tol:
+        break
+      lossOld = result
+  
+
+proc fit*(self: GCDSlow, X: Matrix, y: seq[float64],
+          cfm: var CFMSlow) =
+  ## Fits the factorization machine on X and y by coordinate descent.
+  cfm.init(X)
+  let y = checkTarget(cfm, y)
+  let
+    nSamples = X.shape[0]
+    nFeatures = X.shape[1]
+    maxComponents = cfm.maxComponents
+    alpha0 = cfm.alpha0 * float(nSamples)
+    alpha = cfm.alpha * float(nSamples)
+    beta = cfm.beta * float(nSamples)
+    fitLinear = cfm.fitLinear
+    fitIntercept = cfm.fitIntercept
+    loss = newLossFunction(cfm.loss)
+
+  # caches
+  var
+    yPred = newSeqWith(nSamples, 0.0)
+    A: Matrix = zeros([nSamples, 3])
+    K: Matrix = zeros([cfm.maxComponents, nSamples])
+    p: Vector = zeros([nFeatures])
+    dL: Vector = zeros([nSamples])
+    XTRX: Matrix = zeros([nFeatures, nFeatures])
+    colNormSq: Vector = zeros([nFeatures])
+    isConverged = false
+    lossOld = 0.0
+    lossNew = 0.0
+  
+  # init caches
+  for i in 0..<nSamples:
+    A[i, 0] = 1.0
+  if fitLinear:
+   for i in 0..<nSamples:
+    for j in 0..<nFeatures:
+       colNormSq[j] += X[i, j]^2
+
+  # compute prediction
+  for s in 0..<len(cfm.lams):
+    if cfm.lams[s] != 0.0:
+      for i in 0..<nSamples:
+        if cfm.ignoreDiag:
+          K[s, i] = anovaSlow(X, cfm.P, i, 2, s, nFeatures, 0)
+        else:
+          K[s, i] = polySlow(X, cfm.P, i, 2, s, nFeatures, 0)
+  predict(cfm.P, cfm.w, cfm.lams, cfm.intercept, X, yPred, K, 2)
+  # compute loss
+  for i in 0..<nSamples:
+    lossOld += loss.loss(y[i], yPred[i])
+  if fitLinear:
+    lossOld += alpha * norm(cfm.w, 2)^2
+  if fitIntercept:
+    lossOld += alpha0 * cfm.intercept^2
+  lossOld /= float(nSamples)
+
+  # start iteration
+  for it in 0..<self.maxIter:
+    lossNew = 0.0
+    
+    if fitIntercept:
+      discard fitInterceptCD(cfm.intercept, y, yPred, nSamples, alpha0, loss)
+      lossNew += alpha0 * cfm.intercept^2
+    
+    if fitLinear:
+      discard fitLinearCD(cfm.w, X, y, yPred, colNormSq, alpha, loss)
+      lossNew += alpha0 * norm(cfm.w, 2)^2
+
+    lossNew /= float(nSamples)
+
+    lossNew += fitZ(self, X, y, yPred, cfm.P, cfm.lams, beta, loss, K, p, dL,
+                    maxComponents, self.verbose, cfm.ignoreDiag, XTRX,
+                    cfm.w, cfm.intercept)
+    
+    if abs(lossNew - lossOld) < self.tol:
+      isConverged = true
+      break
+    lossOld = lossNew

--- a/tests/greedy_cd_slow.nim
+++ b/tests/greedy_cd_slow.nim
@@ -124,7 +124,7 @@ proc fitZ(self: GCDSlow, X: Matrix, y: seq[float64],
           for j2 in 0..<nFeatures:
             XTRX[j1, j2] *= 0.5
       # compute dominate eigen vector
-      (evalue, p) = powerIteration(XTRX, self.maxIterPower, self.tol)
+      (evalue, p) = powerMethod(XTRX, self.maxIterPower, self.tol)
       # determine the row index and substitute
       for s in 0..<len(lams):
         if lams[s] == 0.0:

--- a/tests/hazan_slow.nim
+++ b/tests/hazan_slow.nim
@@ -1,0 +1,188 @@
+import nimfm/tensor, nimfm/optimizers/optimizer_base, nimfm/loss, nimfm/utils
+from nimfm/fm_base import checkTarget, checkInitialized
+import math, strformat, strutils
+import cfm_slow, kernels_slow
+
+type
+  HazanSlow* = ref object of BaseCSCOptimizer
+    ## Hazan's algorithm for convex factorization machines with SquaredLoss.
+    ## In this solver, the regularization for P is not 
+    ## squared Frobenius norm but the trace norm for interaction weight
+    ## matrix. 
+    ## This solver solves not regularized problem but constrained problem.
+    ## Regularization parameters alpha0, alpha, and beta
+    ## in ConvexFactorizationMachine are ignored.
+    maxIterPower: int
+    tolPower: float64
+    optimal: bool
+    nTol: int
+    it: int
+
+
+proc newHazanSlow*(
+  maxIter = 100, verbose = 2, tol = 1e-7, nTol=10, maxIterPower = 1000,
+  tolPower = 1e-7, optimal = true): HazanSlow =
+  result = HazanSlow(
+    maxIter: maxIter, tol: tol, nTol: nTol, verbose: verbose,
+    maxIterPower: maxIterPower, tolPower: tolPower, optimal: optimal)
+
+
+proc predict(yPredQuad, yPredLinear: var Vector, K: var Matrix,
+             X, P: Matrix, lams, w: Vector, intercept: float,
+             ignoreDiag: bool) = 
+  let nSamples = X.shape[0]
+  let nFeatures = X.shape[1]
+  mvmul(X, w, yPredLinear)
+  yPredLinear += intercept
+  for s in 0..<len(lams):
+    for i in 0..<nSamples:
+      if ignoreDiag: 
+        K[s, i] = anovaSlow(X, P, i, 2, s, nFeatures, 0)
+      else: 
+        K[s, i] = polySlow(X, P, i, 2, s, nFeatures, 0)
+    yPredQuad += lams[s] * K[s]
+
+
+proc fit*(self: HazanSlow, X: Matrix, y: seq[float64],
+          cfm: var CFMSlow[Squared]) =
+  ## Fits the factorization machine on X and y by coordinate descent.
+  cfm.init(X)
+  let y = checkTarget(cfm, y)
+  let
+    nSamples = X.shape[0]
+    nFeatures = X.shape[1]
+    fitLinear = cfm.fitLinear
+    fitIntercept = cfm.fitIntercept
+    ignoreDiag = cfm.ignoreDiag
+
+  # caches
+  var
+    yPredLinear: Vector = zeros([nSamples])
+    yPredQuad: Vector = zeros([nSamples])
+    residual: Vector = zeros([nSamples])
+    cacheK: Vector = zeros([nSamples])
+    K: Matrix = zeros([len(cfm.lams), nSaMples])
+    Z: Matrix = zeros(X.shape)
+    ZTZ: Matrix
+    w: Vector
+    Xp = zeros([nSamples])
+    resZ: Vector
+    colNormSq: Vector
+    Preconditioner: Matrix
+    lossOld = 0.0
+    lossNew = 0.0
+  
+  for i in 0..<nSamples:
+    Z[i] = X[i]
+  if not cfm.warmStart:
+    self.it = 0
+
+  if fitLinear:
+    w = cfm.w[0..<nFeatures]
+    resZ = zeros([nFeatures])
+    colNormSq = zeros([nFeatures])
+    for i in 0..<nSamples:
+      for j in 0..<nFeatures:
+        colNormSq[j] += X[i, j]^2
+    if fitIntercept: 
+      Z.addCol(ones([nSamples]))
+      w.add(cfm.intercept)
+      colNormSq.add(1.0)
+      resZ.add(0.0)
+    colNormSq += 1e-5
+
+    Preconditioner = zeros([len(colNormSq), len(colNormSq)])
+    for j in 0..<len(colNormSq):
+      Preconditioner[j, j] = 1.0 / colNormSq[j]
+
+  ZTZ = matmul(Z.T, Z)
+  # start optimization
+  lossOld = norm(residual, 2)^2 / float(nSamples)
+  var stepsize = 0.0
+  var nTol = 0
+  self.it = 0
+  for it in 0..<self.maxIter:
+    if not self.optimal and self.it >= cfm.maxComponents:
+      break
+    
+    predict(yPredQuad, yPredLinear, K, X, cfm.P, cfm.lams, cfm.w,
+            cfm.intercept, ignoreDiag)
+    residual = y - yPredQuad - yPredLinear
+    # fit P
+    var gradJ = matmul(X.T*residual, X)
+    if ignoreDiag:
+      for i in 0..<nSamples:
+        for j in 0..<nFeatures:
+          gradJ[j, j] -= residual[i] * X[i, j]^2
+
+    let (_, p) = powerMethod(gradJ, self.maxIterPower, tol=self.tolPower)
+
+    # Add or replace?
+    var s = self.it
+    if s >= cfm.maxComponents: # replace old p
+      s = argmin(cfm.lams) # replace old p whose lambda is minimum
+      cfm.P[s] = p
+
+    for i in 0..<nSamples:
+      if ignoreDiag:
+        cacheK[i] = anovaSlow(X, cfm.P, i, 2, s, nFeatures, 0)
+      else:
+        cacheK[i] = polySlow(X, cfm.P, i, 2, s, nFeatures, 0)
+    
+    if s != len(cfm.lams): # replace old p
+      K[s] = cacheK
+    else:
+      K.addRow(cacheK) # add new p
+
+    # compute yPredQuad
+    yPredQuad[0..^1] = 0.0
+    for s in 0..<len(cfm.lams):
+      yPredQuad += cfm.lams[s] * K[s]
+
+    # compute stepsize
+    if self.optimal:
+      let d = cfm.eta * K[s] - yPredQuad
+      stepsize = dot(d, residual) / norm(d, 2)^2
+      stepsize = min(max(1e-10, stepsize), 1.0)
+    else:
+      stepsize = 2.0 / (float(self.it)+2.0)
+
+    # update lams
+    if sum(cfm.lams) + cfm.eta * stepsize > cfm.eta:
+      cfm.lams *= cfm.eta * (1-stepsize) / sum(cfm.lams)
+    if s == len(cfm.lams):
+      cfm.lams.add(cfm.eta*stepsize)
+    else:
+      cfm.lams[s] += cfm.eta*stepsize
+
+    yPredQuad[0..^1] = 0.0
+    for s in 0..<len(cfm.lams):
+      yPredQuad += cfm.lams[s] * K[s]
+
+    # fit w
+    residual = y - yPredQuad
+    if fitLinear:
+      vmmul(residual, Z, resZ)
+      let maggrad = norm(resZ, 1)
+      let tolCG = 1e-5 * maggrad
+      w *= colNormSq # since we use left-right preconditioning
+      cg(ZTZ, resZ, w, init=false, tol=tolCG, 
+         preconditioner=Preconditioner)
+      cfm.w = w[0..<nFeatures]
+      mvmul(X, cfm.w, yPredLinear)
+      if fitIntercept:
+        cfm.intercept = w[^1]
+    elif fitIntercept:
+      cfm.intercept = sum(residual) / float(nSamples)
+
+    # stopping criterion
+    residual = y - yPredQuad - yPredLinear
+    lossNew = norm(residual, 2)^2  / float(nSamples)
+    if lossOld - lossNew < self.tol:
+      inc(nTol)
+      if nTol == self.nTol:
+        break
+    else:
+      nTol = 0
+    lossOld = lossNew
+    inc(self.it)

--- a/tests/kernels_slow.nim
+++ b/tests/kernels_slow.nim
@@ -1,14 +1,24 @@
 import nimfm/tensor
 import utils
+import math
 
 
-proc anovaSlow*(X: Matrix,  P: Tensor, 
-                i, degree, order, s, d, m:int): float64 = 
+proc anovaSlow*(X: Matrix,  P: Matrix, 
+                i, degree, s, d, m:int): float64 = 
   result = 0.0
   for indices in comb(d+m, degree):
     var prod = 1.0
     for j in indices:
-      prod *= P[order, s, j]
+      prod *= P[s, j]
       if j < d:
         prod *= X[i, j]
     result += prod
+
+
+proc polySlow*(X, P: Matrix, i, degree, s, d, m: int): float64 =
+  result = 0.0
+  for j in 0..<d:
+    result += X[i, j] * P[s, j]
+  for j in 0..<m:
+    result += X[i, d+j] * P[s, d+j]
+  result = result^degree

--- a/tests/sgd_slow.nim
+++ b/tests/sgd_slow.nim
@@ -1,4 +1,4 @@
-import nimfm/loss, nimfm/tensor
+import nimfm/tensor
 import nimfm/optimizers/optimizer_base, nimfm/optimizers/sgd
 import sequtils, math, random
 import kernels_slow, fm_slow, utils
@@ -67,7 +67,7 @@ proc computeAnovaGrad(P: Tensor, X: Matrix, i, degree, order, nAugments: int,
   computeDerivatives(P, X, dA, i, degree, order, nAugments)
 
 
-proc fit*(self: SGDSlow, X: Matrix, y: seq[float64], fm: var FMSlow) =
+proc fit*[L](self: SGDSlow, X: Matrix, y: seq[float64], fm: var FMSlow[L]) =
   fm.init(X)
   let y = fm.checkTarget(y)
   let
@@ -82,7 +82,7 @@ proc fit*(self: SGDSlow, X: Matrix, y: seq[float64], fm: var FMSlow) =
     fitLinear = fm.fitLinear
     fitIntercept = fm.fitIntercept
     nAugments = fm.nAugments
-    loss = newLossFunction(fm.loss)
+    loss = fm.loss
   var
     indices = toSeq(0..<nSamples)
     dA: Tensor = zeros(fm.P.shape)

--- a/tests/test_cd.nim
+++ b/tests/test_cd.nim
@@ -1,6 +1,7 @@
 import unittest
 import utils, cd_slow
-import nimfm/loss, nimfm/dataset, nimfm/tensor, nimfm/factorization_machine
+import nimfm/loss, nimfm/dataset, nimfm/tensor
+import nimfm/factorization_machine, nimfm/fm_base
 import nimfm/optimizers/coordinate_descent
 import fm_slow
 
@@ -27,9 +28,9 @@ suite "Test coordinate descent":
             task = regression, degree = degree, nComponents = nComponents,
             fitLower = fitLower, fitLinear = false,
             fitIntercept = fitIntercept, randomState = 1)
-          var cd = newCoordinateDescent(maxIter = 10, verbose = false, tol = 0)
+          var cd = newCoordinateDescent(maxIter = 10, verbose = 0, tol = 0)
           cd.fit(X, y, fm)
-          for j in 0..<nComponents:
+          for j in 0..<d:
             check fm.w[j] == 0.0
 
 
@@ -48,7 +49,7 @@ suite "Test coordinate descent":
             fitLower = fitLower, fitLinear = fitLinear,
             fitIntercept = false, randomState = 1)
           var cd = newCoordinateDescent(
-            maxIter = 10, verbose = false, tol = 0
+            maxIter = 10, verbose = 0, tol = 0
           )
           cd.fit(X, y, fm)
           check fm.intercept == 0.0
@@ -69,7 +70,7 @@ suite "Test coordinate descent":
               fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
               fitIntercept = fitIntercept, randomState = 1)
             var cdWarm = newCoordinateDescent(
-              maxIter = 1, verbose = false, tol = 0
+              maxIter = 1, verbose = 0, tol = 0
             )
             for i in 0..<10:
               cdWarm.fit(X, y, fmWarm)
@@ -80,7 +81,7 @@ suite "Test coordinate descent":
               fitIntercept = fitIntercept, randomState = 1)
 
             var cd = newCoordinateDescent(
-              maxIter = 10, verbose = false, tol = 0
+              maxIter = 10, verbose = 0, tol = 0
             )
             cd.fit(X, y, fm)
 
@@ -118,7 +119,7 @@ suite "Test coordinate descent":
               fitLower = fitLower, fitLinear = fitLinear,
               fitIntercept = fitIntercept, randomState = 1)
             var cd = newCoordinateDescent(
-              maxIter = 3, verbose = false, tol = 0
+              maxIter = 3, verbose = 0, tol = 0
             )
             cd.fit(X, y, fm)
 
@@ -144,7 +145,7 @@ suite "Test coordinate descent":
               alpha = 1e-9, beta = 1e-9,
               fitIntercept = fitIntercept, randomState = 1)
             var cd = newCoordinateDescent(
-              maxIter = 20, verbose = false, tol = 0
+              maxIter = 20, verbose = 0, tol = 0
             )
             fm.init(X)
             let scoreBefore = fm.score(X, y)
@@ -170,7 +171,7 @@ suite "Test coordinate descent":
               fitIntercept = fitIntercept, randomState = 1,
               alpha0 = 0, alpha = 0, beta = 0)
             var cd = newCoordinateDescent(
-              maxIter = 100, verbose = false, tol = 0
+              maxIter = 100, verbose = 0, tol = 0
             )
             cd.fit(X, y, fmWeakReg)
             

--- a/tests/test_cd.nim
+++ b/tests/test_cd.nim
@@ -28,7 +28,7 @@ suite "Test coordinate descent":
             task = regression, degree = degree, nComponents = nComponents,
             fitLower = fitLower, fitLinear = false,
             fitIntercept = fitIntercept, randomState = 1)
-          var cd = newCoordinateDescent(maxIter = 10, verbose = 0, tol = 0)
+          var cd = newCD(maxIter = 10, verbose = 0, tol = 0)
           cd.fit(X, y, fm)
           for j in 0..<d:
             check fm.w[j] == 0.0
@@ -48,7 +48,7 @@ suite "Test coordinate descent":
             task = regression, degree = degree, nComponents = nComponents,
             fitLower = fitLower, fitLinear = fitLinear,
             fitIntercept = false, randomState = 1)
-          var cd = newCoordinateDescent(
+          var cd = newCD(
             maxIter = 10, verbose = 0, tol = 0
           )
           cd.fit(X, y, fm)
@@ -69,7 +69,7 @@ suite "Test coordinate descent":
               task = regression, degree = degree, nComponents = nComponents,
               fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
               fitIntercept = fitIntercept, randomState = 1)
-            var cdWarm = newCoordinateDescent(
+            var cdWarm = newCD(
               maxIter = 1, verbose = 0, tol = 0
             )
             for i in 0..<10:
@@ -80,7 +80,7 @@ suite "Test coordinate descent":
               fitLower = fitLower, fitLinear = fitLinear,
               fitIntercept = fitIntercept, randomState = 1)
 
-            var cd = newCoordinateDescent(
+            var cd = newCD(
               maxIter = 10, verbose = 0, tol = 0
             )
             cd.fit(X, y, fm)
@@ -110,7 +110,7 @@ suite "Test coordinate descent":
               task = regression, degree = degree, nComponents = nComponents,
               fitLower = fitLower, fitLinear = fitLinear,
               fitIntercept = fitIntercept, randomState = 1)
-            var cdSlow = newCoordinateDescentSlow(maxIter = 3, tol = 0)
+            var cdSlow = newCDSlow(maxIter = 3, tol = 0)
             cdSlow.fit(XMat, y, fmSlow)
 
             # fit fast version
@@ -118,7 +118,7 @@ suite "Test coordinate descent":
               task = regression, degree = degree, nComponents = nComponents,
               fitLower = fitLower, fitLinear = fitLinear,
               fitIntercept = fitIntercept, randomState = 1)
-            var cd = newCoordinateDescent(
+            var cd = newCD(
               maxIter = 3, verbose = 0, tol = 0
             )
             cd.fit(X, y, fm)
@@ -144,7 +144,7 @@ suite "Test coordinate descent":
               fitLower = fitLower, fitLinear = fitLinear, alpha0 = 1e-9,
               alpha = 1e-9, beta = 1e-9,
               fitIntercept = fitIntercept, randomState = 1)
-            var cd = newCoordinateDescent(
+            var cd = newCD(
               maxIter = 20, verbose = 0, tol = 0
             )
             fm.init(X)
@@ -170,7 +170,7 @@ suite "Test coordinate descent":
               fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
               fitIntercept = fitIntercept, randomState = 1,
               alpha0 = 0, alpha = 0, beta = 0)
-            var cd = newCoordinateDescent(
+            var cd = newCD(
               maxIter = 100, verbose = 0, tol = 0
             )
             cd.fit(X, y, fmWeakReg)

--- a/tests/test_dataset.nim
+++ b/tests/test_dataset.nim
@@ -120,8 +120,6 @@ proc hstack(dataseq: seq[seq[seq[float64]]]): seq[seq[float64]] =
 
 suite "Test datasets":
   const nSamples: int = 4
-  const nFeatures: int = 6
-  const nNz: int = 5
   var data: seq[seq[float64]]
   newSeq(data, 4)
   data[0] = @[0.0, 0.0, 1.0, 0.0, -4.2, 0.0]

--- a/tests/test_greedy_cd.nim
+++ b/tests/test_greedy_cd.nim
@@ -7,7 +7,7 @@ import nimfm/optimizers/greedy_coordinate_descent
 import random
 
 
-suite "Test coordinate descent":
+suite "Test greedy coordinate descent":
   let
     n = 50
     d = 6
@@ -49,6 +49,7 @@ suite "Test coordinate descent":
       gcd.fit(X, y, cfm)
       check cfm.intercept == 0.0
 
+
   test "Test warmStart":
     for fitLinear in [true, false]:
       for fitIntercept in [true, false]:
@@ -69,18 +70,17 @@ suite "Test coordinate descent":
           gcdWarm.fit(X, y, cfmWarm)
 
         randomize(1)
-        var fm = newConvexFactorizationMachine(
+        var cfm = newConvexFactorizationMachine(
           task = regression, maxComponents = maxComponents,
           fitLinear = fitLinear, fitIntercept = fitIntercept)
 
-        var cd = newGreedyCoordinateDescent(
+        var gcd = newGreedyCoordinateDescent(
           maxIter = 10, verbose = 0, tol = 0
         )
-        cd.fit(X, y, fm)
-
-        check abs(fm.intercept-cfmWarm.intercept) < 1e-5
-        checkAlmostEqual(fm.w, cfmWarm.w, atol = 1e-5)
-        checkAlmostEqual(fm.lams, cfmWarm.lams, atol = 1e-5)
+        gcd.fit(X, y, cfm)
+        check abs(cfm.intercept-cfmWarm.intercept) < 1e-5
+        checkAlmostEqual(cfm.w, cfmWarm.w, atol = 1e-5)
+        checkAlmostEqual(cfm.lams, cfmWarm.lams, atol = 1e-5)
   
 
   # Too slow!
@@ -103,7 +103,7 @@ suite "Test coordinate descent":
           task = regression,  maxComponents = maxComponents,
           fitLinear = fitLinear, fitIntercept = fitIntercept)
         var gcdSlow = newGCDSlow(
-          maxIter = 3, tol = 0, maxIterPower=1000)
+          maxIter = 10, tol = 0, maxIterPower=1000, tolPower=0.0)
         gcdSlow.fit(XMat, y, cfmSlow)
 
         # fit fast version
@@ -112,16 +112,16 @@ suite "Test coordinate descent":
           task = regression, maxComponents = maxComponents,
           fitLinear = fitLinear, fitIntercept = fitIntercept)
         var gcd = newGreedyCoordinateDescent(
-          maxIter = 3, verbose = 0, tol = 0,
+          maxIter = 10, verbose = 0, tol = 0, tolPower=0.0,
           maxIterPower=1000
         )
         gcd.fit(X, y, cfm)
 
+        #check cfm.score(X, y) == cfmSlow.score(X, y)
         check abs(cfm.intercept-cfmSlow.intercept) < 1e-3
         checkAlmostEqual(cfm.w, cfmSlow.w)
         checkAlmostEqual(cfm.lams, cfmSlow.lams)
         
-
   test "Test score":
     for fitLinear in [true, false]:
       for fitIntercept in [true, false]:
@@ -142,6 +142,7 @@ suite "Test coordinate descent":
         let scoreBefore = cfm.score(X, y)
         gcd.fit(X, y, cfm)
         check cfm.score(X, y) < scoreBefore
+
 
   test "Test regularization":
     for fitLinear in [true, false]:

--- a/tests/test_greedy_cd.nim
+++ b/tests/test_greedy_cd.nim
@@ -15,162 +15,181 @@ suite "Test greedy coordinate descent":
 
 
   test "Test fitLinear":
-    for fitIntercept in [true, false]:
-      var
-        X: CSCDataset
-        y: seq[float64]
-      createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                      explicit, false, fitIntercept)
-
-      # fit fast version
-      var cfm = newConvexFactorizationMachine(
-        task = regression,  maxComponents = maxComponents,
-        fitLinear = false, fitIntercept = fitIntercept)
-      var gcd = newGreedyCoordinateDescent(maxIter = 10, verbose = 0, tol = 0)
-      gcd.fit(X, y, cfm)
-      for j in 0..<d:
-        check cfm.w[j] == 0.0
-
-
-  test "Test fitIntercept":
-    for fitLinear in [true, false]:
-      var
-        X: CSCDataset
-        y: seq[float64]
-      createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                      explicit, fitLinear, false)
-      # fit fast version
-      var cfm = newConvexFactorizationMachine(
-        task = regression, maxComponents = maxComponents,
-        fitLinear = fitLinear, fitIntercept = false)
-      var gcd = newGreedyCoordinateDescent(
-        maxIter = 10, verbose = 0, tol = 0
-      )
-      gcd.fit(X, y, cfm)
-      check cfm.intercept == 0.0
-
-
-  test "Test warmStart":
-    for fitLinear in [true, false]:
+    for refitFully in [true, false]:
       for fitIntercept in [true, false]:
         var
           X: CSCDataset
           y: seq[float64]
         createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                        explicit, fitLinear, fitIntercept)
-        randomize(1)
-        var cfmWarm = newConvexFactorizationMachine(
-          task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, warmStart = true,
-          fitIntercept = fitIntercept)
-        var gcdWarm = newGreedyCoordinateDescent(
-          maxIter = 1, verbose = 0, tol = 0
-        )
-        for i in 0..<10:
-          gcdWarm.fit(X, y, cfmWarm)
+                        explicit, false, fitIntercept)
 
-        randomize(1)
+        # fit fast version
+        var cfm = newConvexFactorizationMachine(
+          task = regression,  maxComponents = maxComponents,
+          fitLinear = false, fitIntercept = fitIntercept)
+        var gcd = newGreedyCD(maxIter = 10, verbose = 0, tol = 0,
+                              refitFully=refitFully)
+        gcd.fit(X, y, cfm)
+        for j in 0..<d:
+          check cfm.w[j] == 0.0
+
+
+  test "Test fitIntercept":
+    for refitFully in [true, false]:
+      for fitLinear in [true, false]:
+        var
+          X: CSCDataset
+          y: seq[float64]
+        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                        explicit, fitLinear, false)
+        # fit fast version
         var cfm = newConvexFactorizationMachine(
           task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, fitIntercept = fitIntercept)
-
-        var gcd = newGreedyCoordinateDescent(
-          maxIter = 10, verbose = 0, tol = 0
+          fitLinear = fitLinear, fitIntercept = false)
+        var gcd = newGreedyCD(
+          maxIter = 10, verbose = 0, tol = 0, refitFully=refitFully
         )
         gcd.fit(X, y, cfm)
-        check abs(cfm.intercept-cfmWarm.intercept) < 1e-5
-        checkAlmostEqual(cfm.w, cfmWarm.w, atol = 1e-5)
-        checkAlmostEqual(cfm.lams, cfmWarm.lams, atol = 1e-5)
+        check cfm.intercept == 0.0
+
+
+  test "Test warmStart":
+    for refitFully in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept)
+            randomize(1)
+            var cfmWarm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true,
+              fitIntercept = fitIntercept, ignoreDiag=ignoreDiag)
+            var gcdWarm = newGreedyCD(
+              maxIter = 1, verbose = 0, tol = 0, refitFully=refitFully,
+            )
+            for i in 0..<10:
+              gcdWarm.fit(X, y, cfmWarm)
+
+            randomize(1)
+            var cfm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag=ignoreDiag)
+
+            var gcd = newGreedyCD(
+              maxIter = 10, verbose = 0, tol = 0, refitFully=refitFully
+            )
+            gcd.fit(X, y, cfm)
+            check abs(cfm.intercept-cfmWarm.intercept) < 1e-5
+            checkAlmostEqual(cfm.w, cfmWarm.w, atol = 1e-5)
+            checkAlmostEqual(cfm.lams, cfmWarm.lams, atol = 1e-5)
   
 
   # Too slow!
   test "Comparison to naive implementation":
-    for fitLinear in [true, false]:
-      for fitIntercept in [true, false]:
-        var
-          X: CSCDataset
-          y: seq[float64]
-          XMat = zeros([n, d])
-        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                        explicit, fitLinear, fitIntercept,
-                        threshold=0.3)
-        for j in 0..<d:
-          for (i, val) in X.getCol(j):
-            XMat[i, j] = val
-        # fit slow version
-        randomize(1)
-        var cfmSlow = newCFMSlow(
-          task = regression,  maxComponents = maxComponents,
-          fitLinear = fitLinear, fitIntercept = fitIntercept)
-        var gcdSlow = newGCDSlow(
-          maxIter = 10, tol = 0, maxIterPower=1000, tolPower=0.0)
-        gcdSlow.fit(XMat, y, cfmSlow)
+    for refitFully in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+              XMat = zeros([n, d])
 
-        # fit fast version
-        randomize(1)
-        var cfm = newConvexFactorizationMachine(
-          task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, fitIntercept = fitIntercept)
-        var gcd = newGreedyCoordinateDescent(
-          maxIter = 10, verbose = 0, tol = 0, tolPower=0.0,
-          maxIterPower=1000
-        )
-        gcd.fit(X, y, cfm)
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept,
+                            threshold=0.3)
+            for j in 0..<d:
+              for (i, val) in X.getCol(j):
+                XMat[i, j] = val
+            # fit slow version
+            randomize(1)
+            var cfmSlow = newCFMSlow(
+              task = regression,  maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag = ignoreDiag)
+            var gcdSlow = newGCDSlow(
+              maxIter = 10, tol = 0, maxIterPower=1000, tolPower=0.0,
+              refitFully=refitFully, maxIterADMM=100)
+            gcdSlow.fit(XMat, y, cfmSlow)
 
-        #check cfm.score(X, y) == cfmSlow.score(X, y)
-        check abs(cfm.intercept-cfmSlow.intercept) < 1e-3
-        checkAlmostEqual(cfm.w, cfmSlow.w)
-        checkAlmostEqual(cfm.lams, cfmSlow.lams)
-        
+            # fit fast version
+            randomize(1)
+            var cfm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag = ignoreDiag)
+
+            var gcd = newGreedyCD(
+              maxIter = 10, verbose = 0, tol = 0, tolPower=0.0,
+              maxIterPower=1000, refitFully = refitFully,
+              maxIterADMM=100)
+            gcd.fit(X, y, cfm)
+
+            check abs(cfm.intercept-cfmSlow.intercept) < 1e-5
+            checkAlmostEqual(cfm.w, cfmSlow.w, atol=1e-5)
+            checkAlmostEqual(cfm.lams, cfmSlow.lams, atol=1e-5)
+            checkAlmostEqual(cfm.P, cfm.P, atol=1e-5)
+
+
   test "Test score":
-    for fitLinear in [true, false]:
-      for fitIntercept in [true, false]:
-        var
-          X: CSCDataset
-          y: seq[float64]
-        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                        explicit, fitLinear, fitIntercept)
+    for refitFully in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept)
 
-        var cfm: ConvexFactorizationMachine = newConvexFactorizationMachine(
-          task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, alpha0 = 1e-9,
-          alpha = 1e-9, beta = 1e-9, fitIntercept = fitIntercept)
-        var gcd = newGreedyCoordinateDescent(
-          maxIter = 20, verbose = 0, tol = 0
-        )
-        init(cfm, X)
-        let scoreBefore = cfm.score(X, y)
-        gcd.fit(X, y, cfm)
-        check cfm.score(X, y) < scoreBefore
+            var cfm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, alpha0 = 1e-9,
+              alpha = 1e-9, beta = 1e-9, fitIntercept = fitIntercept,
+              ignoreDiag=ignoreDiag)
+            var gcd = newGreedyCD(
+              maxIter = 20, verbose = 0, tol = 0, refitFully=refitFully
+            )
+            init(cfm, X)
+            let scoreBefore = cfm.score(X, y)
+            gcd.fit(X, y, cfm)
+            check cfm.score(X, y) < scoreBefore
 
 
   test "Test regularization":
-    for fitLinear in [true, false]:
-      for fitIntercept in [true, false]:
-        var
-          X: CSCDataset
-          y: seq[float64]
-        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
-                        explicit, fitLinear, fitIntercept,
-                        scale=1.0)
+    for refitFully in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept,
+                            scale=1.0)
 
-        var cfmWeakReg = newConvexFactorizationMachine(
-          task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, warmStart = true,
-          fitIntercept = fitIntercept, alpha0 = 0, alpha = 0, beta = 0)
-        var gcd = newGreedyCoordinateDescent(
-          maxIter = 100, verbose = 0, tol = 0
-        )
-        gcd.fit(X, y, cfmWeakReg)
+            var cfmWeakReg = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true, ignoreDiag=ignoreDiag,
+              fitIntercept = fitIntercept, alpha0 = 0, alpha = 0, beta = 0)
+            var gcd = newGreedyCD(
+              maxIter = 100, verbose = 0, tol = 0, refitFully=refitFully
+            )
+            gcd.fit(X, y, cfmWeakReg)
             
-        var cfmStrongReg = newConvexFactorizationMachine(
-          task = regression, maxComponents = maxComponents,
-          fitLinear = fitLinear, warmStart = true,
-          fitIntercept = fitIntercept,
-          alpha0 = 1000, alpha = 1000, beta = 1000)
-        gcd.fit(X, y, cfmStrongReg)
+            var cfmStrongReg = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true,
+              fitIntercept = fitIntercept, ignoreDiag=ignoreDiag,
+              alpha0 = 1000, alpha = 1000, beta = 1000)
+            gcd.fit(X, y, cfmStrongReg)
 
-        check cfmWeakReg.score(X, y) < cfmStrongReg.score(X, y)
-        check abs(cfmWeakReg.intercept) >= abs(cfmStrongReg.intercept)
-        check norm(cfmWeakReg.w, 2) >= norm(cfmStrongReg.w, 2)
-        check norm(cfmWeakReg.lams, 2) >= norm(cfmStrongReg.lams, 2)
+            check cfmWeakReg.score(X, y) < cfmStrongReg.score(X, y)
+            check abs(cfmWeakReg.intercept) >= abs(cfmStrongReg.intercept)
+            check norm(cfmWeakReg.w, 2) >= norm(cfmStrongReg.w, 2)
+            check norm(cfmWeakReg.lams, 2) >= norm(cfmStrongReg.lams, 2)

--- a/tests/test_greedy_cd.nim
+++ b/tests/test_greedy_cd.nim
@@ -1,0 +1,175 @@
+import unittest
+import utils, greedy_cd_slow, cfm_slow
+import nimfm/loss, nimfm/dataset, nimfm/tensor
+import nimfm/convex_factorization_machine, nimfm/fm_base
+from nimfm/factorization_machine import FitLowerKind
+import nimfm/optimizers/greedy_coordinate_descent
+import random
+
+
+suite "Test coordinate descent":
+  let
+    n = 50
+    d = 6
+    maxComponents = 6
+
+
+  test "Test fitLinear":
+    for fitIntercept in [true, false]:
+      var
+        X: CSCDataset
+        y: seq[float64]
+      createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                      explicit, false, fitIntercept)
+
+      # fit fast version
+      var cfm = newConvexFactorizationMachine(
+        task = regression,  maxComponents = maxComponents,
+        fitLinear = false, fitIntercept = fitIntercept)
+      var gcd = newGreedyCoordinateDescent(maxIter = 10, verbose = 0, tol = 0)
+      gcd.fit(X, y, cfm)
+      for j in 0..<d:
+        check cfm.w[j] == 0.0
+
+
+  test "Test fitIntercept":
+    for fitLinear in [true, false]:
+      var
+        X: CSCDataset
+        y: seq[float64]
+      createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                      explicit, fitLinear, false)
+      # fit fast version
+      var cfm = newConvexFactorizationMachine(
+        task = regression, maxComponents = maxComponents,
+        fitLinear = fitLinear, fitIntercept = false)
+      var gcd = newGreedyCoordinateDescent(
+        maxIter = 10, verbose = 0, tol = 0
+      )
+      gcd.fit(X, y, cfm)
+      check cfm.intercept == 0.0
+
+  test "Test warmStart":
+    for fitLinear in [true, false]:
+      for fitIntercept in [true, false]:
+        var
+          X: CSCDataset
+          y: seq[float64]
+        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                        explicit, fitLinear, fitIntercept)
+        randomize(1)
+        var cfmWarm = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, warmStart = true,
+          fitIntercept = fitIntercept)
+        var gcdWarm = newGreedyCoordinateDescent(
+          maxIter = 1, verbose = 0, tol = 0
+        )
+        for i in 0..<10:
+          gcdWarm.fit(X, y, cfmWarm)
+
+        randomize(1)
+        var fm = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, fitIntercept = fitIntercept)
+
+        var cd = newGreedyCoordinateDescent(
+          maxIter = 10, verbose = 0, tol = 0
+        )
+        cd.fit(X, y, fm)
+
+        check abs(fm.intercept-cfmWarm.intercept) < 1e-5
+        checkAlmostEqual(fm.w, cfmWarm.w, atol = 1e-5)
+        checkAlmostEqual(fm.lams, cfmWarm.lams, atol = 1e-5)
+  
+
+  # Too slow!
+  test "Comparison to naive implementation":
+    for fitLinear in [true, false]:
+      for fitIntercept in [true, false]:
+        var
+          X: CSCDataset
+          y: seq[float64]
+          XMat = zeros([n, d])
+        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                        explicit, fitLinear, fitIntercept,
+                        threshold=0.3)
+        for j in 0..<d:
+          for (i, val) in X.getCol(j):
+            XMat[i, j] = val
+        # fit slow version
+        randomize(1)
+        var cfmSlow = newCFMSlow(
+          task = regression,  maxComponents = maxComponents,
+          fitLinear = fitLinear, fitIntercept = fitIntercept)
+        var gcdSlow = newGCDSlow(
+          maxIter = 3, tol = 0, maxIterPower=1000)
+        gcdSlow.fit(XMat, y, cfmSlow)
+
+        # fit fast version
+        randomize(1)
+        var cfm = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, fitIntercept = fitIntercept)
+        var gcd = newGreedyCoordinateDescent(
+          maxIter = 3, verbose = 0, tol = 0,
+          maxIterPower=1000
+        )
+        gcd.fit(X, y, cfm)
+
+        check abs(cfm.intercept-cfmSlow.intercept) < 1e-3
+        checkAlmostEqual(cfm.w, cfmSlow.w)
+        checkAlmostEqual(cfm.lams, cfmSlow.lams)
+        
+
+  test "Test score":
+    for fitLinear in [true, false]:
+      for fitIntercept in [true, false]:
+        var
+          X: CSCDataset
+          y: seq[float64]
+        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                        explicit, fitLinear, fitIntercept)
+
+        var cfm: ConvexFactorizationMachine = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, alpha0 = 1e-9,
+          alpha = 1e-9, beta = 1e-9, fitIntercept = fitIntercept)
+        var gcd = newGreedyCoordinateDescent(
+          maxIter = 20, verbose = 0, tol = 0
+        )
+        init(cfm, X)
+        let scoreBefore = cfm.score(X, y)
+        gcd.fit(X, y, cfm)
+        check cfm.score(X, y) < scoreBefore
+
+  test "Test regularization":
+    for fitLinear in [true, false]:
+      for fitIntercept in [true, false]:
+        var
+          X: CSCDataset
+          y: seq[float64]
+        createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                        explicit, fitLinear, fitIntercept,
+                        scale=1.0)
+
+        var cfmWeakReg = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, warmStart = true,
+          fitIntercept = fitIntercept, alpha0 = 0, alpha = 0, beta = 0)
+        var gcd = newGreedyCoordinateDescent(
+          maxIter = 100, verbose = 0, tol = 0
+        )
+        gcd.fit(X, y, cfmWeakReg)
+            
+        var cfmStrongReg = newConvexFactorizationMachine(
+          task = regression, maxComponents = maxComponents,
+          fitLinear = fitLinear, warmStart = true,
+          fitIntercept = fitIntercept,
+          alpha0 = 1000, alpha = 1000, beta = 1000)
+        gcd.fit(X, y, cfmStrongReg)
+
+        check cfmWeakReg.score(X, y) < cfmStrongReg.score(X, y)
+        check abs(cfmWeakReg.intercept) >= abs(cfmStrongReg.intercept)
+        check norm(cfmWeakReg.w, 2) >= norm(cfmStrongReg.w, 2)
+        check norm(cfmWeakReg.lams, 2) >= norm(cfmStrongReg.lams, 2)

--- a/tests/test_hazan.nim
+++ b/tests/test_hazan.nim
@@ -1,0 +1,192 @@
+import unittest
+import utils, hazan_slow, cfm_slow
+import nimfm/loss, nimfm/dataset, nimfm/tensor
+import nimfm/convex_factorization_machine, nimfm/fm_base
+from nimfm/factorization_machine import FitLowerKind
+import nimfm/optimizers/hazan
+import random
+
+
+suite "Test hazan":
+  let
+    n = 50
+    d = 6
+    maxComponents = 6
+
+
+  test "Test fitLinear":
+    for optimal in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitIntercept in [true, false]:
+          var
+            X: CSCDataset
+            y: seq[float64]
+          createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                          explicit, false, fitIntercept)
+
+          # fit fast version
+          var cfm = newConvexFactorizationMachine(
+            task = regression,  maxComponents = maxComponents,
+            fitLinear = false, fitIntercept = fitIntercept)
+          var hazan = newHazan(maxIter = 10, verbose = 0, tol = 0,
+                              optimal=optimal)
+          hazan.fit(X, y, cfm)
+          for j in 0..<d:
+            check cfm.w[j] == 0.0
+
+
+  test "Test fitIntercept":
+    for optimal in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          var
+            X: CSCDataset
+            y: seq[float64]
+          createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                          explicit, fitLinear, false)
+          # fit fast version
+          var cfm = newConvexFactorizationMachine(
+            task = regression, maxComponents = maxComponents,
+            fitLinear = fitLinear, fitIntercept = false)
+          var hazan = newHazan(
+            maxIter = 10, verbose = 0, tol = 0, optimal=optimal
+          )
+          hazan.fit(X, y, cfm)
+          check cfm.intercept == 0.0
+
+
+  test "Test warmStart":
+    for optimal in [true, false]:
+      for ignoreDiag in [true]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept)
+            randomize(1)
+            var cfmWarm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true,
+              fitIntercept = fitIntercept, ignoreDiag=ignoreDiag)
+            var hazanWarm = newHazan(
+              maxIter = 1, verbose = 0, tol = -100, optimal=optimal,
+            )
+            for i in 0..<100:
+              hazanWarm.fit(X, y, cfmWarm)
+
+            randomize(1)
+            var cfm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag=ignoreDiag)
+
+            var hazan = newHazan(
+              maxIter = 100, verbose = 0, tol = -100, optimal=optimal
+            )
+            hazan.fit(X, y, cfm)
+            check abs(cfm.intercept-cfmWarm.intercept) < 1e-5
+            checkAlmostEqual(cfm.w, cfmWarm.w, atol = 1e-5)
+            checkAlmostEqual(cfm.lams, cfmWarm.lams, atol = 1e-5)
+
+
+  # Too slow!
+  test "Comparison to naive implementation":
+    for optimal in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [false, false]:
+          for fitIntercept in [false, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+              XMat = zeros([n, d])
+
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept,
+                            threshold=0.3)
+            for j in 0..<d:
+              for (i, val) in X.getCol(j):
+                XMat[i, j] = val
+            # fit slow version
+            randomize(1)
+            var cfmSlow = newCFMSlow(
+              task = regression,  maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag = ignoreDiag)
+            var hazanSlow = newHazanSlow(
+              maxIter = 50, tol = 0, maxIterPower=1000, tolPower=0.0,
+              optimal=optimal)
+            hazanSlow.fit(XMat, y, cfmSlow)
+
+            # fit fast version
+            randomize(1)
+            var cfm = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, fitIntercept = fitIntercept,
+              ignoreDiag = ignoreDiag)
+
+            var hazan = newHazan(
+              maxIter = 50, verbose = 0, tol = 0, tolPower=0.0,
+              maxIterPower=1000, optimal = optimal)
+            hazan.fit(X, y, cfm)
+
+            check abs(cfm.intercept-cfmSlow.intercept) < 1e-5
+            checkAlmostEqual(cfm.w, cfmSlow.w, atol=1e-5)
+            checkAlmostEqual(cfm.lams, cfmSlow.lams, atol=1e-5)
+            checkAlmostEqual(cfm.P, cfm.P, atol=1e-5)
+
+
+  test "Test score":
+    for optimal in [true]:
+      for fitLinear in [true, false]:
+        for fitIntercept in [true]:
+          var
+            X: CSCDataset
+            y: seq[float64]
+          createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                          explicit, fitLinear, fitIntercept)
+
+          var cfm = newConvexFactorizationMachine(
+            task = regression, maxComponents = 1000,
+            fitLinear = fitLinear, eta=10, fitIntercept = fitIntercept,
+            ignoreDiag=true)
+          var hazan = newHazan(
+            maxIter = 100, ntol=10, verbose = 0, tol = 0, optimal=optimal,
+            maxIterPower=100
+          )
+          init(cfm, X)
+          let scoreBefore = cfm.score(X, y)
+          hazan.fit(X, y, cfm)
+          check cfm.score(X, y) < scoreBefore
+
+
+  test "Test regularization":
+    for optimal in [true, false]:
+      for ignoreDiag in [true, false]:
+        for fitLinear in [true, false]:
+          for fitIntercept in [true, false]:
+            var
+              X: CSCDataset
+              y: seq[float64]
+            createFMDataset(X, y, n, d, 2, maxComponents div 2, 42,
+                            explicit, fitLinear, fitIntercept,
+                            scale=1.0)
+
+            var cfmWeakReg = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true, ignoreDiag=ignoreDiag,
+              fitIntercept = fitIntercept, eta=1000)
+            var hazan = newHazan(
+              maxIter = 100, verbose = 0, tol = -100, optimal=optimal,
+            )
+            hazan.fit(X, y, cfmWeakReg)
+            
+            var cfmStrongReg = newConvexFactorizationMachine(
+              task = regression, maxComponents = maxComponents,
+              fitLinear = fitLinear, warmStart = true,
+              fitIntercept = fitIntercept, ignoreDiag=ignoreDiag,
+              eta=0.1)
+            hazan.fit(X, y, cfmStrongReg)
+
+            check norm(cfmWeakReg.lams, 1) >= norm(cfmStrongReg.lams, 1)

--- a/tests/test_kernels.nim
+++ b/tests/test_kernels.nim
@@ -27,16 +27,16 @@ suite "Test ANOVA Kernel Computation":
     for m in 0..<nAug+1:
       for degree in 2..<6:
         for s in 0..<k:
-          anova(XCSC, P, K, degree, 0, s, m)
+          anova(XCSC, P[0], K, degree, s, m)
           for i in 0..<n:
-            let expect = anovaSlow(XMat, P, i, degree, 0, s, d, m)
+            let expect = anovaSlow(XMat, P[0], i, degree, s, d, m)
             check abs(K[i, degree] -  expect) < 1e-6
 
   test "Test ANOVA Kernel for CSR":
     for m in 0..<nAug+1:
       for degree in 2..<6:
         for s in 0..<k:
-          anova(XCSR, P, K, degree, 0, s, m)
+          anova(XCSR, P[0], K, degree, s, m)
           for i in 0..<n:
-            let expect = anovaSlow(XMat, P, i, degree, 0, s, d, m)
+            let expect = anovaSlow(XMat, P[0], i, degree, s, d, m)
             check abs(K[i, degree] - expect) < 1e-6

--- a/tests/test_sgd.nim
+++ b/tests/test_sgd.nim
@@ -1,6 +1,7 @@
 import unittest
 import utils, sgd_slow
-import nimfm/loss, nimfm/dataset, nimfm/tensor, nimfm/factorization_machine
+import nimfm/loss, nimfm/dataset, nimfm/tensor
+import nimfm/factorization_machine, nimfm/fm_base
 import nimfm/optimizers/sgd
 import fm_slow
 
@@ -27,9 +28,9 @@ suite "Test stochastic gradient descent":
             task = regression, degree = degree, nComponents = nComponents,
             fitLower = fitLower, fitLinear = false,
             fitIntercept = fitIntercept, randomState = 1)
-          var sgd = newSGD(maxIter = 10, verbose = false, tol = 0)
+          var sgd = newSGD(maxIter = 10, verbose = 0, tol = 0)
           sgd.fit(X, y, fm)
-          for j in 0..<nComponents:
+          for j in 0..<d:
             check fm.w[j] == 0.0
 
 
@@ -48,7 +49,7 @@ suite "Test stochastic gradient descent":
             fitLower = fitLower, fitLinear = fitLinear,
             fitIntercept = false, randomState = 1)
           var sgd = newSGD(
-            maxIter = 10, verbose = false, tol = 0
+            maxIter = 10, verbose = 0, tol = 0
           )
           sgd.fit(X, y, fm)
           check fm.intercept == 0.0
@@ -69,7 +70,7 @@ suite "Test stochastic gradient descent":
               fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
               fitIntercept = fitIntercept, randomState = 1)
             var sgdWarm = newSGD(
-              maxIter = 1, verbose = false, tol = 0, shuffle = false
+              maxIter = 1, verbose = 0, tol = 0, shuffle = false
             )
             for i in 0..<10:
               sgdWarm.fit(X, y, fmWarm)
@@ -79,7 +80,7 @@ suite "Test stochastic gradient descent":
               fitIntercept = fitIntercept, randomState = 1)
 
             var sgd = newSGD(
-              maxIter = 10, verbose = false, tol = 0, shuffle = false
+              maxIter = 10, verbose = 0, tol = 0, shuffle = false
             )
             sgd.fit(X, y, fm)
 
@@ -117,7 +118,7 @@ suite "Test stochastic gradient descent":
               fitLower = fitLower, fitLinear = fitLinear,
               fitIntercept = fitIntercept, randomState = 1)
             var sgd = newSGD(
-              maxIter = 5, verbose = false, tol = 0
+              maxIter = 5, verbose = 0, tol = 0
             )
             sgd.fit(X, y, fm)
 
@@ -143,7 +144,7 @@ suite "Test stochastic gradient descent":
               alpha = 1e-9, beta = 1e-9, fitIntercept = fitIntercept,
               randomState = 1)
             var sgd = newSGD(
-              maxIter = 20, verbose = false, tol = 0
+              maxIter = 20, verbose = 0, tol = 0
             )
             fm.init(X)
             let scoreBefore = fm.score(X, y)
@@ -169,7 +170,7 @@ suite "Test stochastic gradient descent":
               fitIntercept = fitIntercept, randomState = 1,
               alpha0 = 0, alpha = 0, beta = 0)
             var sgd = newSGD(
-              maxIter = 100, verbose = false, tol = 0
+              maxIter = 100, verbose = 0, tol = 0
             )
             sgd.fit(X, y, fmWeakReg)
             

--- a/tests/test_sgd.nim
+++ b/tests/test_sgd.nim
@@ -166,23 +166,22 @@ suite "Test stochastic gradient descent":
 
             var fmWeakReg = newFactorizationMachine(
               task = regression, degree = degree, nComponents = nComponents,
-              fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
+              fitLower = fitLower, fitLinear = fitLinear, warmStart = false,
               fitIntercept = fitIntercept, randomState = 1,
-              alpha0 = 0, alpha = 0, beta = 0)
+              alpha0 = 1e-4, alpha = 1e-4, beta = 1e-4)
             var sgd = newSGD(
-              maxIter = 100, verbose = 0, tol = 0
+              maxIter = 200, verbose = 0, tol = 0
             )
             sgd.fit(X, y, fmWeakReg)
             
             var fmStrongReg = newFactorizationMachine(
               task = regression, degree = degree, nComponents = nComponents,
-              fitLower = fitLower, fitLinear = fitLinear, warmStart = true,
+              fitLower = fitLower, fitLinear = fitLinear, warmStart = false,
               fitIntercept = fitIntercept, randomState = 2,
-              alpha0 = 1000, alpha = 1000, beta = 1000)
+              alpha0 = 10000, alpha = 10000, beta = 10000)
+
             sgd.fit(X, y, fmStrongReg)
 
             check fmWeakReg.score(X, y) < fmStrongReg.score(X, y)
-
-            check abs(fmWeakReg.intercept) >= abs(fmStrongReg.intercept)
             check norm(fmWeakReg.w, 2) >= norm(fmStrongReg.w, 2)
             check norm(fmWeakReg.P, 2) >= norm(fmStrongReg.P, 2)

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -1,4 +1,4 @@
-import nimfm/factorization_machine, nimfm/tensor, nimfm/dataset
+import nimfm/factorization_machine, nimfm/tensor, nimfm/dataset, nimfm/fm_base
 import sequtils, random, unittest
 
 


### PR DESCRIPTION
Issue #7 
## Major changes
- Add `ConvexFactorizaionMachine`.
- Add `GreedyCD` optimizer： [greedy coordinate descent](http://mblondel.org/publications/mblondel-ecmlpkdd2015.pdf) for the regularized problem.
- Add `Hazan` optimizer : [Hazan's algorithm](https://riken-yamada.github.io/paper/KDD_2017_errata.pdf) for the constrained regression problem.

## Optional
- Change loss API: `FactorizationMachine` and `ConvexFactorizationMachine` compose a loss as a generic parameter that is a ref object with `loss`, `dloss`, and `mu` proc. So, users can use/define their own loss functions easily.
- Add `Huber` loss.
- Add many tensor/matrix/vector operations.
- Chage solver name: `CoordinateDescent` -> `CD`.